### PR TITLE
Feature: Apple 로그인 구현

### DIFF
--- a/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
+++ b/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
@@ -23,10 +23,13 @@ public final class DefaultAuthRepository: AuthRepository {
         self.keyChainStorage = keyChainStorage
     }
     
-    public func fetchSignIn(_ idToken: String) async throws {
-        let requestDTO: SignInRequestDTO = .init(idToken: idToken)
+    public func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws {
         
-        let result = await authProvider.request(.signIn(requestDTO))
+        let requestDTO: SignInRequestDTO = .init(idToken: idToken, authorizationCode: authorizationCode)
+        
+        let result = await authProvider.request(.signIn(requestDTO, type: type))
+        
+        print(requestDTO)
         
         let responseDTO = try ResultHandler.handleResult(
             result: result,

--- a/Projects/Data/AuthData/Sources/RequestDTO/SignInRequestDTO.swift
+++ b/Projects/Data/AuthData/Sources/RequestDTO/SignInRequestDTO.swift
@@ -10,4 +10,13 @@ import Foundation
 
 public struct SignInRequestDTO: Encodable {
     let idToken: String
+    let authorizationCode: String?
+    
+    public init(
+        idToken: String,
+        authorizationCode: String? = nil
+    ) {
+        self.idToken = idToken
+        self.authorizationCode = authorizationCode
+    }
 }

--- a/Projects/Data/AuthData/Sources/TargetType/AuthTargetType.swift
+++ b/Projects/Data/AuthData/Sources/TargetType/AuthTargetType.swift
@@ -10,16 +10,22 @@ import Foundation
 import Moya
 
 import BaseData
+import AuthDomain
 
 public enum AuthTargetType {
-    case signIn(_ requestDTO: SignInRequestDTO)
+    case signIn(_ requestDTO: SignInRequestDTO, type: SignInType)
 }
 
 extension AuthTargetType: BaseTargetType {
     public var path: String {
         switch self {
-        case .signIn:
-            return "/auth/login/google"
+        case let .signIn(_, type):
+            switch type {
+            case .apple:
+                return "/auth/login/apple"
+            case .google:
+                return "/auth/login/google"
+            }
         }
     }
     
@@ -32,7 +38,7 @@ extension AuthTargetType: BaseTargetType {
     
     public var task: Moya.Task {
         switch self {
-        case let .signIn(requestDTO):
+        case let .signIn(requestDTO, _):
             return .requestJSONEncodable(requestDTO)
         }
     }

--- a/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
+++ b/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
@@ -7,5 +7,5 @@
 //
 
 public protocol AuthRepository {
-    func fetchSignIn(_ idToken: String) async throws
+    func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws
 }

--- a/Projects/Domain/AuthDomain/Sources/Types/SignInType.swift
+++ b/Projects/Domain/AuthDomain/Sources/Types/SignInType.swift
@@ -1,0 +1,14 @@
+//
+//  SignInType.swift
+//  AuthDomain
+//
+//  Created by 선민재 on 3/15/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+
+public enum SignInType {
+    case google
+    case apple
+}

--- a/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
+++ b/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
@@ -9,7 +9,7 @@
 import BaseDomain
 
 public protocol AuthUseCase {
-    func executeSignIn(_ idToken: String) async throws -> Bool
+    func executeSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws -> Bool
 }
 
 public final class DefaultAuthUseCase: AuthUseCase {
@@ -24,8 +24,8 @@ public final class DefaultAuthUseCase: AuthUseCase {
         self.userRepository = userRepository
     }
     
-    public func executeSignIn(_ idToken: String) async throws -> Bool {
-        try await authRepository.fetchSignIn(idToken)
+    public func executeSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws -> Bool {
+        try await authRepository.fetchSignIn(idToken: idToken, authorizationCode: authorizationCode, type: type)
         
         let userInfo = try await userRepository.fetchUserInfo()
         

--- a/Projects/Presentation/AuthPresentation/Sources/Controller/LoginViewController.swift
+++ b/Projects/Presentation/AuthPresentation/Sources/Controller/LoginViewController.swift
@@ -19,8 +19,11 @@ public final class LoginViewController: UIViewController {
     private let disposeBag: DisposeBag = DisposeBag()
     private let viewModel: LoginViewModel
     
-    private let appleLoginButtonDidTap: PublishRelay<Void> = .init()
-    private let oauthAuthorizationCompleted: PublishRelay<String> = .init()
+    private let appleAuthorizationCompleted: PublishRelay<(
+        idToken: String,
+        authorizationCode: String
+    )> = .init()
+    private let googleAuthorizationCompleted: PublishRelay<String> = .init()
     
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -83,8 +86,8 @@ public final class LoginViewController: UIViewController {
 extension LoginViewController {
     private func bindViewModel() {
         let input = LoginViewModel.Input(
-            appleLoginButtonDidTap: appleLoginButtonDidTap,
-            oauthAuthorizationCompleted: oauthAuthorizationCompleted
+            appleAuthorizationCompleted: appleAuthorizationCompleted,
+            googleAuthorizationCompleted: googleAuthorizationCompleted
         )
         let _ = viewModel.translation(input)
     }
@@ -93,15 +96,16 @@ extension LoginViewController {
         appleSignInButton.rx.controlEvent(.touchUpInside)
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
-                self.appleLoginButtonDidTap.accept(())
-//                let appleIDProvider = ASAuthorizationAppleIDProvider()
-//                let request = appleIDProvider.createRequest()
-//                request.requestedScopes = [.fullName, .email]
-//                
-//                let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-//                authorizationController.delegate = self
-//                authorizationController.presentationContextProvider = self
-//                authorizationController.performRequests()
+                let appleIDProvider = ASAuthorizationAppleIDProvider()
+                let request = appleIDProvider.createRequest()
+                request.requestedScopes = [.fullName, .email]
+                
+                let authorizationController = ASAuthorizationController(
+                    authorizationRequests: [request]
+                )
+                authorizationController.delegate = self
+                authorizationController.presentationContextProvider = self
+                authorizationController.performRequests()
             })
             .disposed(by: disposeBag)
         
@@ -114,7 +118,7 @@ extension LoginViewController {
                     guard error == nil,
                           let idToken = result?.user.idToken?.tokenString else { return }
                     
-                    self.oauthAuthorizationCompleted.accept(idToken)
+                    self.googleAuthorizationCompleted.accept(idToken)
                 }
             })
             .disposed(by: disposeBag)
@@ -126,27 +130,16 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-//        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
-//              let authorizationCode = appleIDCredential.authorizationCode,
-//              let identityToken = appleIDCredential.identityToken,
-//              let authorizationCodeString = String(data: authorizationCode, encoding: .utf8),
-//              let tokenString = String(data: identityToken, encoding: .utf8) else { return }
-
-        // 유니크한 값
-//        LoginCheckManager.shared.userAppleIdentity = appleIDCredential.user
-//        LoginCheckManager.shared.userAppleIdentityToken = tokenString
-//        LoginCheckManager.shared.userAppleAuthorizationCode = authorizationCodeString
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let authorizationCode = appleIDCredential.authorizationCode,
+              let identityToken = appleIDCredential.identityToken,
+              let authorizationCodeString = String(data: authorizationCode, encoding: .utf8),
+              let tokenString = String(data: identityToken, encoding: .utf8) else { return }
         
-//        Task {
-//            do {
-//                try await LoginCheckManager.shared.requestAuthKeys(signinType: .apple, token: authorizationCodeString)
-//            } catch let error {
-//                DispatchQueue.main.async {
-//                    self.alertWith(message: error.localizedDescription)
-//                }
-//            }
-//        }
-        
+        appleAuthorizationCompleted.accept((
+            idToken: tokenString,
+            authorizationCode: authorizationCodeString
+        ))
     }
 }
 

--- a/Projects/Presentation/AuthPresentation/Sources/ViewModel/LoginViewModel.swift
+++ b/Projects/Presentation/AuthPresentation/Sources/ViewModel/LoginViewModel.swift
@@ -27,8 +27,8 @@ public final class LoginViewModel {
     }
     
     struct Input {
-        let appleLoginButtonDidTap: PublishRelay<Void>
-        let oauthAuthorizationCompleted: PublishRelay<String>
+        let appleAuthorizationCompleted: PublishRelay<(idToken: String, authorizationCode: String)>
+        let googleAuthorizationCompleted: PublishRelay<String>
     }
     
     struct Output {
@@ -37,16 +37,24 @@ public final class LoginViewModel {
     
     func translation(_ input: Input) -> Output {
         
-        input.appleLoginButtonDidTap
+        input.appleAuthorizationCompleted
             .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                self.delegate?.moveToHome()
+            .subscribe(onNext: { (self, element) in
+                self.requestSignIn(
+                    idToken: element.idToken,
+                    authorizationCode: element.authorizationCode,
+                    type: .apple
+                )
             })
             .disposed(by: disposeBag)
         
-        input.oauthAuthorizationCompleted
+        input.googleAuthorizationCompleted
             .subscribe(with: self, onNext: { (self, idToken) in
-                self.requestSignIn(idToken)
+                self.requestSignIn(
+                    idToken: idToken,
+                    authorizationCode: nil,
+                    type: .google
+                )
             })
             .disposed(by: disposeBag)
         
@@ -55,9 +63,13 @@ public final class LoginViewModel {
 }
 
 extension LoginViewModel {
-    private func requestSignIn(_ idToken: String) {
+    private func requestSignIn(idToken: String, authorizationCode: String?, type: SignInType) {
         Task {
-            let isOnboardingFinished: Bool = try await authUseCase.executeSignIn(idToken)
+            let isOnboardingFinished: Bool = try await authUseCase.executeSignIn(
+                idToken: idToken,
+                authorizationCode: authorizationCode,
+                type: type
+            )
 
             await MainActor.run {
                 if isOnboardingFinished {


### PR DESCRIPTION
## 변경 사항

- `SignInType` 열거형 추가 (`.apple` / `.google`)
- `AuthRepository`, `AuthUseCase` 인터페이스에 `authorizationCode` 및 `type` 파라미터 추가
- `AuthTargetType`에서 `SignInType`에 따라 API 경로 분기 처리 (`/auth/login/apple`, `/auth/login/google`)
- `SignInRequestDTO`에 `authorizationCode` 옵셔널 필드 추가
- `LoginViewController`에서 Apple Sign In 플로우 실제 구현 (기존 주석 코드 제거 및 적용)
- `LoginViewModel` Input을 `appleAuthorizationCompleted` / `googleAuthorizationCompleted` 릴레이로 분리

## 테스트 방법

- [ ] 앱 실행 후 로그인 화면 진입
- [ ] Apple 로그인 버튼 탭 → Apple 인증 시트 정상 표시 확인
- [ ] Apple 계정으로 인증 완료 → 서버에 idToken + authorizationCode 전달 및 로그인 성공 확인
- [ ] Google 로그인 버튼 탭 → Google 인증 완료 후 로그인 성공 확인
- [ ] Apple / Google 각각 로그인 후 올바른 API 엔드포인트(`/auth/login/apple`, `/auth/login/google`)로 요청되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)