### PR TITLE
Feature: MemorySealDialog 재사용 컴포넌트 추가 및 로그아웃 다이얼로그 연동

### DIFF
--- a/Projects/Presentation/ProfilePresentation/Sources/Controller/SettingsViewController.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/Controller/SettingsViewController.swift
@@ -16,16 +16,18 @@ import DesignSystem
 public final class SettingsViewController: UIViewController {
     private let disposeBag: DisposeBag = DisposeBag()
     private let viewModel: SettingsViewModel
-
+    
+    private let logoutButtonDidTap: PublishRelay<Void> = .init()
+    
     private let navigationView: MemorySealNavigationView = {
         let view = MemorySealNavigationView()
         return view
     }()
-
+    
     private let rowsContainerView = UIView()
-
+    
     private let appVersionRowView = UIView()
-
+    
     private let appVersionTitleLabel: UILabel = {
         let label = UILabel()
         label.text = "앱 버전"
@@ -33,7 +35,7 @@ public final class SettingsViewController: UIViewController {
         label.font = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
         return label
     }()
-
+    
     private let appVersionValueLabel: UILabel = {
         let label = UILabel()
         label.text = "v0.2"
@@ -41,7 +43,7 @@ public final class SettingsViewController: UIViewController {
         label.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
         return label
     }()
-
+    
     private let termsOfServiceButton: DisclosureButton = {
         let button = DisclosureButton(
             title: "이용 약관",
@@ -49,7 +51,7 @@ public final class SettingsViewController: UIViewController {
         )
         return button
     }()
-
+    
     private let logoutButton: DisclosureButton = {
         let button = DisclosureButton(
             title: "로그아웃",
@@ -57,7 +59,7 @@ public final class SettingsViewController: UIViewController {
         )
         return button
     }()
-
+    
     private let withdrawalButton: DisclosureButton = {
         let button = DisclosureButton(
             title: "회원탈퇴",
@@ -65,21 +67,22 @@ public final class SettingsViewController: UIViewController {
         )
         return button
     }()
-
+    
     public init(with viewModel: SettingsViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         
         bindViewModel()
+        bindButtons()
         
         addSubviews()
         setLayout()
@@ -93,29 +96,57 @@ extension SettingsViewController {
         let input = SettingsViewModel.Input(
             backButtonDidTap: navigationView.backButtonDidTap,
             termsOfServiceDidTap: termsOfServiceButton.rx.tap,
-            logoutDidTap: logoutButton.rx.tap,
+            logoutButtonDidTap: logoutButtonDidTap.asObservable(),
             withdrawalDidTap: withdrawalButton.rx.tap
         )
         let _ = viewModel.translation(input)
     }
+    
+    private func bindButtons() {
+        logoutButton.rx.tap
+            .subscribe(with: self, onNext: { (self, _) in
+                self.showLogoutDiaLogView()
+            })
+            .disposed(by: disposeBag)
+    }
 }
 
-// MARK: - Layout
-
 extension SettingsViewController {
+    private func showLogoutDiaLogView() {
+        let dialog = DialogView.show(
+            on: view,
+            title: "로그아웃",
+            message: "메실에서 로그아웃 하시겠습니까?",
+            cancelTitle: "유지",
+            confirmTitle: "로그아웃"
+        )
+        
+        dialog.confirmButtonDidTap
+            .subscribe(with: self, onNext: { (self, _) in
+                self.logoutButtonDidTap.accept(())
+            })
+            .disposed(by: disposeBag)
+        
+        dialog.cancelButtonDidTap
+            .subscribe(with: self, onNext: { (self, _) in
+                dialog.dismiss()
+            })
+            .disposed(by: disposeBag)
+    }
+    
     private func addSubviews() {
         view.addSubview(navigationView)
         view.addSubview(rowsContainerView)
-
+        
         rowsContainerView.addSubview(appVersionRowView)
         appVersionRowView.addSubview(appVersionTitleLabel)
         appVersionRowView.addSubview(appVersionValueLabel)
-
+        
         rowsContainerView.addSubview(termsOfServiceButton)
         rowsContainerView.addSubview(logoutButton)
         rowsContainerView.addSubview(withdrawalButton)
     }
-
+    
     private func setLayout() {
         navigationView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -123,40 +154,40 @@ extension SettingsViewController {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing)
             $0.height.equalTo(56)
         }
-
+        
         rowsContainerView.snp.makeConstraints {
             $0.top.equalTo(navigationView.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
-
+        
         appVersionRowView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(4)
             $0.height.equalTo(48)
         }
-
+        
         appVersionTitleLabel.snp.makeConstraints {
             $0.leading.equalToSuperview()
             $0.centerY.equalToSuperview()
         }
-
+        
         appVersionValueLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview()
             $0.centerY.equalToSuperview()
         }
-
+        
         termsOfServiceButton.snp.makeConstraints {
             $0.top.equalTo(appVersionRowView.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(4)
             $0.height.equalTo(48)
         }
-
+        
         logoutButton.snp.makeConstraints {
             $0.top.equalTo(termsOfServiceButton.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(4)
             $0.height.equalTo(48)
         }
-
+        
         withdrawalButton.snp.makeConstraints {
             $0.top.equalTo(logoutButton.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(4)

--- a/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
@@ -24,7 +24,7 @@ public final class SettingsViewModel {
     struct Input {
         let backButtonDidTap: ControlEvent<Void>
         let termsOfServiceDidTap: ControlEvent<Void>
-        let logoutDidTap: ControlEvent<Void>
+        let logoutButtonDidTap: Observable<Void>
         let withdrawalDidTap: ControlEvent<Void>
     }
 
@@ -45,7 +45,7 @@ public final class SettingsViewModel {
             })
             .disposed(by: disposeBag)
 
-        input.logoutDidTap
+        input.logoutButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
                 self.delegate?.moveToLogout()

--- a/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
@@ -1,0 +1,183 @@
+//
+//  DialogView.swift
+//  DesignSystem
+//
+//  Created by 선민재 on 3/16/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+public final class DialogView: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
+        label.textColor = DesignSystemAsset.ColorAssests.grey5.color
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
+        label.textColor = DesignSystemAsset.ColorAssests.grey5.color
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let textStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        return stack
+    }()
+
+    private let cancelButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.backgroundColor = DesignSystemAsset.ColorAssests.grey1.color
+        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        button.setTitleColor(DesignSystemAsset.ColorAssests.grey4.color, for: .normal)
+        button.layer.cornerRadius = 12
+        return button
+    }()
+
+    private let confirmButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
+        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 12
+        return button
+    }()
+
+    private let buttonStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 8
+        stack.distribution = .fillEqually
+        return stack
+    }()
+
+    public var cancelButtonDidTap: ControlEvent<Void> {
+        return cancelButton.rx.tap
+    }
+
+    public var confirmButtonDidTap: ControlEvent<Void> {
+        return confirmButton.rx.tap
+    }
+
+    private weak var dimmingView: UIView?
+
+    public init(
+        title: String,
+        message: String,
+        cancelTitle: String,
+        confirmTitle: String
+    ) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        messageLabel.text = message
+        cancelButton.setTitle(cancelTitle, for: .normal)
+        confirmButton.setTitle(confirmTitle, for: .normal)
+
+        self.backgroundColor = .white
+        self.layer.cornerRadius = 24
+
+        self.addSubviews()
+        self.setLayout()
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @discardableResult
+    public static func show(
+        on view: UIView,
+        title: String,
+        message: String,
+        cancelTitle: String,
+        confirmTitle: String
+    ) -> DialogView {
+        let dialog = DialogView(
+            title: title,
+            message: message,
+            cancelTitle: cancelTitle,
+            confirmTitle: confirmTitle
+        )
+
+        let dimming = UIView()
+        dimming.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        dimming.alpha = 0
+        view.addSubview(dimming)
+        dimming.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+        view.addSubview(dialog)
+        dialog.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+
+        dialog.dimmingView = dimming
+        dialog.alpha = 0
+        dialog.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+
+        UIView.animate(withDuration: 0.25) {
+            dimming.alpha = 1
+            dialog.alpha = 1
+            dialog.transform = .identity
+        }
+
+        return dialog
+    }
+
+    public func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+        let performDismiss = { [weak self] in
+            self?.dimmingView?.removeFromSuperview()
+            self?.removeFromSuperview()
+            completion?()
+        }
+
+        guard animated else {
+            performDismiss()
+            return
+        }
+
+        UIView.animate(withDuration: 0.2, animations: { [weak self] in
+            self?.dimmingView?.alpha = 0
+            self?.alpha = 0
+        }, completion: { _ in
+            performDismiss()
+        })
+    }
+}
+
+extension DialogView {
+    private func addSubviews() {
+        textStackView.addArrangedSubview(titleLabel)
+        textStackView.addArrangedSubview(messageLabel)
+
+        buttonStackView.addArrangedSubview(cancelButton)
+        buttonStackView.addArrangedSubview(confirmButton)
+
+        addSubview(textStackView)
+        addSubview(buttonStackView)
+    }
+
+    private func setLayout() {
+        textStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(28)
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+
+        buttonStackView.snp.makeConstraints {
+            $0.top.equalTo(textStackView.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(24)
+            $0.height.equalTo(48)
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

- **DialogView (MemorySealDialog) 추가** — `Projects/Shared/DesignSystem/Sources/Dialog/`
  - 앱 전역에서 재사용 가능한 확인 다이얼로그 UIView 컴포넌트
  - `static func show(on:title:message:cancelTitle:confirmTitle:)` — 딤 오버레이 + fade/scale 애니메이션으로 표시
  - `func dismiss(animated:completion:)` — 딤 뷰와 함께 fade-out 제거
  - `cancelButtonDidTap` / `confirmButtonDidTap` — RxCocoa `ControlEvent<Void>` 노출
  - Figma 스펙 반영: cornerRadius 24, padding top 28/sides 24/bottom 24, 버튼 48pt/radius 12

- **SettingsViewController** — 로그아웃 버튼 탭 시 DialogView 표시 연동
  - 확인 탭 → `logoutButtonDidTap` relay 방출 → ViewModel 로그아웃 처리
  - 취소 탭 → 다이얼로그 dismiss

- **SettingsViewModel** — `logoutDidTap` 타입을 `Observable<Void>`로 변경 (PublishRelay 연동)

## 테스트 방법

- [ ] 설정 화면 진입 후 "로그아웃" 항목 탭 → 다이얼로그 표시 확인
- [ ] 다이얼로그 등장 시 딤 오버레이 + fade/scale 애니메이션 확인
- [ ] "유지" 탭 → 다이얼로그 dismiss 확인
- [ ] "로그아웃" 탭 → dismiss 후 로그아웃 처리 흐름 확인 (현재 stub)
- [ ] DialogView를 다른 화면에서도 재사용 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)