### PR TITLE
Feature: Auto SignIn 기능 추가

### DIFF
--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -3,9 +3,10 @@ import UIKit
 import AppFeature
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    
+
     var window: UIWindow?
-    
+    var appCoordinator: AppCoordinator?
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
@@ -14,9 +15,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let navigationController = UINavigationController()
         window?.rootViewController = navigationController
 
-        let appCoordinator: AppCoordinator = AppCoordinator(with: navigationController)
-        appCoordinator.moveToLoginCoordinator()
-        
+        let coordinator = AppCoordinator(with: navigationController)
+        appCoordinator = coordinator
+        coordinator.start()
+
         window?.makeKeyAndVisible()
     }
 }

--- a/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
+++ b/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
@@ -23,6 +23,10 @@ public final class DefaultAuthRepository: AuthRepository {
         self.keyChainStorage = keyChainStorage
     }
     
+    public func hasAccessToken() -> Bool {
+        return keyChainStorage.read(forKey: .accessToken) != nil
+    }
+
     public func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws {
         
         let requestDTO: SignInRequestDTO = .init(idToken: idToken, authorizationCode: authorizationCode)

--- a/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
+++ b/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
@@ -8,4 +8,5 @@
 
 public protocol AuthRepository {
     func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws
+    func hasAccessToken() -> Bool
 }

--- a/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
+++ b/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
@@ -8,14 +8,19 @@
 
 import BaseDomain
 
+public enum AutoSignInError: Error {
+    case noToken
+}
+
 public protocol AuthUseCase {
     func executeSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws -> Bool
+    func executeAutoSignIn() async throws -> Bool
 }
 
 public final class DefaultAuthUseCase: AuthUseCase {
     private let authRepository: AuthRepository
     private let userRepository: UserRepository
-    
+
     public init(
         authRepository: AuthRepository,
         userRepository: UserRepository
@@ -23,12 +28,23 @@ public final class DefaultAuthUseCase: AuthUseCase {
         self.authRepository = authRepository
         self.userRepository = userRepository
     }
-    
+
     public func executeSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws -> Bool {
         try await authRepository.fetchSignIn(idToken: idToken, authorizationCode: authorizationCode, type: type)
-        
+
         let userInfo = try await userRepository.fetchUserInfo()
-        
+
+        return userInfo.isOnboarding
+    }
+
+    public func executeAutoSignIn() async throws -> Bool {
+                
+        guard authRepository.hasAccessToken() else {
+            throw AutoSignInError.noToken
+        }
+
+        let userInfo = try await userRepository.fetchUserInfo()
+
         return userInfo.isOnboarding
     }
 }

--- a/Projects/Feature/AppFeature/Project.swift
+++ b/Projects/Feature/AppFeature/Project.swift
@@ -12,6 +12,7 @@ let project = Project.makeModule(
     name: "AppFeature",
     product: .staticFramework,
     dependencies: [
+        .Feature.SplashFeature,
         .Feature.SignUpFeature,
         .Feature.AuthFeature,
         .Feature.HomeFeature,

--- a/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
+++ b/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import SplashFeature
 import AuthFeature
 import SignUpFeature
 import HomeFeature
@@ -16,6 +17,7 @@ import MemoryFeature
 
 public final class AppCoordinator {
     private let navigationController: UINavigationController
+    private var splashCoordinator: SplashCoordinator?
     private var profileCoordinator: ProfileCoordinator?
 
     public init(
@@ -23,7 +25,14 @@ public final class AppCoordinator {
     ) {
         self.navigationController = navigationController
     }
-    
+
+    public func start() {
+        let coordinator = SplashCoordinator(with: navigationController)
+        coordinator.delegate = self
+        splashCoordinator = coordinator
+        coordinator.start()
+    }
+
     public func moveToLoginCoordinator() {
         let loginCoordinator: LoginCoordinator = LoginCoordinator(
             with: navigationController
@@ -71,6 +80,23 @@ public final class AppCoordinator {
             with: navigationController
         )
         memoryCoordinator.start()
+    }
+}
+
+extension AppCoordinator: SplashCoordinatorDelegate {
+    public func splashCoordinatorMoveToLogin() {
+        splashCoordinator = nil
+        moveToLoginCoordinator()
+    }
+
+    public func splashCoordinatorMoveToHome() {
+        splashCoordinator = nil
+        moveToHomeCoorinator()
+    }
+
+    public func splashCoordinatorMoveToSignUp() {
+        splashCoordinator = nil
+        moveToSignUpCoordinator()
     }
 }
 

--- a/Projects/Feature/SplashFeature/Project.swift
+++ b/Projects/Feature/SplashFeature/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: "SplashFeature",
+    product: .staticFramework,
+    dependencies: [
+        .Presentation.SplashPresentation,
+        .Data.AuthData,
+        .Data.BaseData
+    ]
+)

--- a/Projects/Feature/SplashFeature/Sources/Coordinator/SplashCoordinator.swift
+++ b/Projects/Feature/SplashFeature/Sources/Coordinator/SplashCoordinator.swift
@@ -1,0 +1,51 @@
+//
+//  SplashCoordinator.swift
+//  SplashFeature
+//
+//  Created by 선민재 on 3/19/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import UIKit
+
+import SplashPresentation
+
+public protocol SplashCoordinatorDelegate: AnyObject {
+    func splashCoordinatorMoveToLogin()
+    func splashCoordinatorMoveToHome()
+    func splashCoordinatorMoveToSignUp()
+}
+
+public final class SplashCoordinator {
+    private let navigationController: UINavigationController
+    private let splashDIContainer: SplashDIContainer = SplashDIContainer()
+
+    public weak var delegate: SplashCoordinatorDelegate?
+
+    public init(with navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    public func start() {
+        let splashViewModel = splashDIContainer.makeSplashViewModel()
+        splashViewModel.delegate = self
+        let splashViewController = splashDIContainer.makeSplashViewController(with: splashViewModel)
+
+        navigationController.pushViewController(splashViewController, animated: false)
+        navigationController.viewControllers = [splashViewController]
+    }
+}
+
+extension SplashCoordinator: SplashViewModelDelegate {
+    public func moveToLogin() {
+        delegate?.splashCoordinatorMoveToLogin()
+    }
+
+    public func moveToHome() {
+        delegate?.splashCoordinatorMoveToHome()
+    }
+
+    public func moveToSignUp() {
+        delegate?.splashCoordinatorMoveToSignUp()
+    }
+}

--- a/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
+++ b/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
@@ -1,0 +1,63 @@
+//
+//  SplashDIContainer.swift
+//  SplashFeature
+//
+//  Created by 선민재 on 3/19/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+import SplashPresentation
+import AuthData
+import AuthDomain
+import BaseData
+import BaseDomain
+
+public final class SplashDIContainer {
+    private func makeAuthProvider() -> MoyaProvider<AuthTargetType> {
+        return MoyaProvider<AuthTargetType>()
+    }
+
+    private func makeUserProvider() -> DefaultProvider<UserTargetType> {
+        return DefaultProvider<UserTargetType>()
+    }
+
+    private func makeKeyChainStorage() -> KeyChainStorage {
+        return DefaultKeyChainStorage()
+    }
+
+    private func makeUserDefaultStorage() -> UserDefaultStorage {
+        return DefaultUserDefaultStorage()
+    }
+
+    private func makeAuthRepository() -> AuthRepository {
+        return DefaultAuthRepository(
+            authProvider: makeAuthProvider(),
+            keyChainStorage: makeKeyChainStorage()
+        )
+    }
+
+    private func makeUserRepository() -> UserRepository {
+        return DefaultUserRepository(
+            provider: makeUserProvider(),
+            userDefaultStorage: makeUserDefaultStorage()
+        )
+    }
+
+    private func makeAuthUseCase() -> AuthUseCase {
+        return DefaultAuthUseCase(
+            authRepository: makeAuthRepository(),
+            userRepository: makeUserRepository()
+        )
+    }
+
+    func makeSplashViewModel() -> SplashViewModel {
+        return SplashViewModel(authUseCase: makeAuthUseCase())
+    }
+
+    func makeSplashViewController(with viewModel: SplashViewModel) -> SplashViewController {
+        return SplashViewController(with: viewModel)
+    }
+}

--- a/Projects/Presentation/SplashPresentation/Project.swift
+++ b/Projects/Presentation/SplashPresentation/Project.swift
@@ -1,0 +1,12 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: "SplashPresentation",
+    product: .staticFramework,
+    dependencies: [
+        .Domain.AuthDomain,
+        .ThridPartyLib.ThridPartyLib,
+        .Shared.DesignSystem
+    ]
+)

--- a/Projects/Presentation/SplashPresentation/Sources/Controller/SplashViewController.swift
+++ b/Projects/Presentation/SplashPresentation/Sources/Controller/SplashViewController.swift
@@ -1,0 +1,69 @@
+//
+//  SplashViewController.swift
+//  SplashPresentation
+//
+//  Created by 선민재 on 3/19/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import UIKit
+import SnapKit
+
+public final class SplashViewController: UIViewController {
+    private let viewModel: SplashViewModel
+
+    private let logoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "MemorySeal_Logo")
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    public init(with viewModel: SplashViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpView()
+        setUpConstraints()
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        activityIndicator.startAnimating()
+        viewModel.executeAutoSignIn()
+    }
+}
+
+private extension SplashViewController {
+    func setUpView() {
+        view.backgroundColor = .white
+        view.addSubview(logoImageView)
+        view.addSubview(activityIndicator)
+    }
+
+    func setUpConstraints() {
+        logoImageView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(200)
+            $0.height.equalTo(200)
+        }
+
+        activityIndicator.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(logoImageView.snp.bottom).offset(24)
+        }
+    }
+}

--- a/Projects/Presentation/SplashPresentation/Sources/ViewModel/SplashViewModel.swift
+++ b/Projects/Presentation/SplashPresentation/Sources/ViewModel/SplashViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  SplashViewModel.swift
+//  SplashPresentation
+//
+//  Created by 선민재 on 3/19/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import AuthDomain
+
+public protocol SplashViewModelDelegate: AnyObject {
+    func moveToLogin()
+    func moveToHome()
+    func moveToSignUp()
+}
+
+public final class SplashViewModel {
+    private let authUseCase: AuthUseCase
+
+    public weak var delegate: SplashViewModelDelegate?
+
+    public init(authUseCase: AuthUseCase) {
+        self.authUseCase = authUseCase
+    }
+
+    public func executeAutoSignIn() {
+        Task {
+            do {
+                let isOnboarding = try await authUseCase.executeAutoSignIn()
+                await MainActor.run {
+                    if isOnboarding {
+                        delegate?.moveToHome()
+                    } else {
+                        delegate?.moveToSignUp()
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    delegate?.moveToLogin()
+                }
+            }
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Dependency+Project.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+Project.swift
@@ -103,6 +103,11 @@ public extension TargetDependency.Feature {
         target: "MemoryFeature",
         path: .relativeToRoot("Projects/Feature/MemoryFeature")
     )
+
+    static let SplashFeature = TargetDependency.project(
+        target: "SplashFeature",
+        path: .relativeToRoot("Projects/Feature/SplashFeature")
+    )
 }
 
 public extension TargetDependency.Presentation {
@@ -140,6 +145,11 @@ public extension TargetDependency.Presentation {
     static let MemoryPresentation = TargetDependency.project(
         target: "MemoryPresentation",
         path: .relativeToRoot("Projects/Presentation/MemoryPresentation")
+    )
+
+    static let SplashPresentation = TargetDependency.project(
+        target: "SplashPresentation",
+        path: .relativeToRoot("Projects/Presentation/SplashPresentation")
     )
 }
 


### PR DESCRIPTION
## 변경 사항

### 신규 모듈
- `SplashFeature`: `SplashCoordinator`, `SplashDIContainer` 추가
- `SplashPresentation`: `SplashViewController`(로고 + ActivityIndicator), `SplashViewModel` 추가

### 기존 모듈 수정
- `AuthUseCase`: `executeAutoSignIn()` 메서드 및 `AutoSignInError` 추가
- `AuthRepository`: `hasAccessToken()` 메서드 추가 (Keychain 토큰 존재 여부 확인)
- `DefaultAuthRepository`: `hasAccessToken()` 구현
- `AppCoordinator`: `start()` 메서드 추가, `SplashCoordinatorDelegate` 채택
- `SceneDelegate`: `appCoordinator`를 인스턴스 프로퍼티로 유지하여 비동기 완료 후 해제 방지
- `Dependency+Project.swift`: `SplashFeature`, `SplashPresentation` 모듈 등록

### 앱 실행 흐름
```
SceneDelegate → AppCoordinator.start()
  └─ SplashCoordinator → SplashViewController (로고 + 스피너)
       └─ viewDidAppear → executeAutoSignIn()
            ├─ [토큰 없음] → LoginViewController
            ├─ [isOnboarding=true] → HomeViewController
            ├─ [isOnboarding=false] → SignUpViewController
            └─ [네트워크 오류 / refresh 실패] → LoginViewController
```

> `AuthorizationInterceptor`가 401 발생 시 자동으로 Refresh + Retry를 처리하므로 별도 Refresh 로직 불필요

## 테스트 방법

- [ ] Keychain에 토큰이 없는 상태로 앱 실행 → 로그인 화면으로 이동하는지 확인
- [ ] 로그인 후 앱 재실행 → `isOnboarding` 값에 따라 Home 또는 SignUp으로 이동하는지 확인
- [ ] 유효한 AccessToken이 있고 `isOnboarding=true`인 경우 → Home으로 이동 확인
- [ ] 유효한 AccessToken이 있고 `isOnboarding=false`인 경우 → SignUp으로 이동 확인
- [ ] AccessToken 만료 상태에서 앱 실행 → Refresh 후 정상 라우팅 확인
- [ ] RefreshToken도 만료된 경우 → 로그인 화면으로 이동 확인
- [ ] 네트워크 오프라인 상태에서 앱 실행 → 로그인 화면으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)