### PR TITLE
Feature: 로그아웃 API 연동 및 Moya Logger 추가

### DIFF
--- a/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
+++ b/Projects/Data/AuthData/Sources/Repository/DefaultAuthRepository.swift
@@ -14,39 +14,49 @@ import BaseData
 public final class DefaultAuthRepository: AuthRepository {
     private let authProvider: MoyaProvider<AuthTargetType>
     private let keyChainStorage: KeyChainStorage
-    
+    private let userDefaultStorage: UserDefaultStorage
+
     public init(
         authProvider: MoyaProvider<AuthTargetType>,
-        keyChainStorage: KeyChainStorage
+        keyChainStorage: KeyChainStorage,
+        userDefaultStorage: UserDefaultStorage
     ) {
         self.authProvider = authProvider
         self.keyChainStorage = keyChainStorage
+        self.userDefaultStorage = userDefaultStorage
     }
-    
+
     public func hasAccessToken() -> Bool {
         return keyChainStorage.read(forKey: .accessToken) != nil
     }
 
     public func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws {
-        
+
         let requestDTO: SignInRequestDTO = .init(idToken: idToken, authorizationCode: authorizationCode)
-        
+
         let result = await authProvider.request(.signIn(requestDTO, type: type))
-        
+
         let responseDTO = try ResultHandler.handleResult(
             result: result,
             responseType: SignInResponseDTO.self,
             errorType: AuthError.self
         )
-        
+
         keyChainStorage.add(
             value: responseDTO.accessToken,
             forKey: .accessToken
         )
-        
+
         keyChainStorage.add(
             value: responseDTO.refreshToken,
             forKey: .refreshToken
         )
+    }
+
+    public func logout() async throws {
+        _ = await authProvider.request(.logout)
+        _ = keyChainStorage.delete(key: .accessToken)
+        _ = keyChainStorage.delete(key: .refreshToken)
+        userDefaultStorage.remove(forKey: .userId)
     }
 }

--- a/Projects/Data/AuthData/Sources/TargetType/AuthTargetType.swift
+++ b/Projects/Data/AuthData/Sources/TargetType/AuthTargetType.swift
@@ -14,6 +14,7 @@ import AuthDomain
 
 public enum AuthTargetType {
     case signIn(_ requestDTO: SignInRequestDTO, type: SignInType)
+    case logout
 }
 
 extension AuthTargetType: BaseTargetType {
@@ -26,34 +27,44 @@ extension AuthTargetType: BaseTargetType {
             case .google:
                 return "/auth/login/google"
             }
+        case .logout:
+            return "/auth/logout"
         }
     }
-    
+
     public var method: Moya.Method {
         switch self {
         case .signIn:
             return .post
+        case .logout:
+            return .delete
         }
     }
-    
+
     public var task: Moya.Task {
         switch self {
         case let .signIn(requestDTO, _):
             return .requestJSONEncodable(requestDTO)
+        case .logout:
+            return .requestPlain
         }
     }
-    
+
     public var headers: [String : String]? {
         switch self {
         case .signIn:
             return nil
+        case .logout:
+            return nil
         }
     }
-    
+
     public var isNeededAccessToken: Bool {
         switch self {
         case .signIn:
             return false
+        case .logout:
+            return true
         }
     }
 }

--- a/Projects/Data/BaseData/Sources/Plugin/Logger/LoggerSystem.swift
+++ b/Projects/Data/BaseData/Sources/Plugin/Logger/LoggerSystem.swift
@@ -1,0 +1,155 @@
+//
+//  LoggerSystem.swift
+//  BaseData
+//
+//  Created by 선민재 on 3/30/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+import os
+
+public enum LoggerLevel: String, CaseIterable {
+    case info = "info"
+    case debug = "debug"
+    case warning = "warning"
+    case error = "error"
+    case critical = "critical"
+    
+    var emoji: String {
+        switch self {
+        case .info: return "ℹ️"
+        case .debug: return "🔍"
+        case .warning: return "⚠️"
+        case .error: return "❌"
+        case .critical: return "🚨"
+        }
+    }
+}
+
+public struct LoggerSystem {
+    let category: String
+    let subsystem: String
+    let isEnabled: Bool
+    let allowedLevels: Set<LoggerLevel>?
+    let useOSLog: Bool
+    let useConsole: Bool
+    let showMetadata: Bool // 메타데이터 표시 여부를 제어하는 Bool 타입 프로퍼티 (기본값: `true`)
+    let showSourceInfo: Bool // 소스 정보(파일명, 라인, 함수명) 표시 여부를 제어하는 Bool 타입 프로퍼티 (기본값: `true`)
+    
+    @available(iOS 14.0, *)
+    private var osLogger: Logger {
+        Logger(subsystem: subsystem, category: category)
+    }
+    
+    public init(
+        category: String,
+        subsystem: String = "com.photocard.masterDev",
+        isEnabled: Bool = true,
+        allowedLevels: Set<LoggerLevel>? = nil,
+        useOSLog: Bool = true,
+        useConsole: Bool = true,
+        showMetadata: Bool = true,
+        showSourceInfo: Bool = true
+    ) {
+        self.category = category
+        self.subsystem = subsystem
+        self.isEnabled = isEnabled
+        self.allowedLevels = allowedLevels
+        self.useOSLog = useOSLog
+        self.useConsole = useConsole
+        self.showMetadata = showMetadata // 초기화 시 설정 가능
+        self.showSourceInfo = showSourceInfo // 초기화 시 설정 가능
+    }
+
+    private func log(
+        _ level: LoggerLevel,
+        message: String,
+        metadata: [String: Any] = [:],
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        guard isEnabled else { return }
+        
+        let fileName = (file as NSString).lastPathComponent
+        let timestamp = DateFormatter.logTimestamp.string(from: Date())
+        let levelEmoji = level.emoji
+        
+        // 소스 정보 포맷 생성
+        let sourceInfo = showSourceInfo ? " [\(fileName)#\(line) \(function)]" : ""
+        
+#if DEBUG
+        // OS Log 전송
+        if #available(iOS 14.0, *),
+           useOSLog
+        {
+            let osMessage = "[\(timestamp) \(levelEmoji) \(fileName)#\(line) \(function)] \(message)"
+            
+            switch level {
+            case .info:
+                osLogger.info("\(osMessage, privacy: .public)")
+            case .debug:
+                osLogger.debug("\(osMessage, privacy: .public)")
+            case .warning:
+                osLogger.warning("\(osMessage, privacy: .public)")
+            case .error:
+                osLogger.error("\(osMessage, privacy: .public)")
+            case .critical:
+                osLogger.fault("\(osMessage, privacy: .public)")
+            }
+        }
+#endif
+        
+        // 허용된 레벨만큼 콘솔 출력되도록
+        if let allowed = allowedLevels, allowed.contains(level) == false {
+            return
+        }
+        
+        // 콘솔 출력
+#if DEBUG
+        if  useConsole {
+            print("----------------------------------------------------------------------------------------------------------")
+            print("[\(timestamp)] \(levelEmoji) \(level.rawValue.uppercased()) [\(category)]:\(sourceInfo) \(message)")
+            
+            // 메타데이터가 있으면 별도로 출력
+            if !metadata.isEmpty && showMetadata {
+                print("📋 Metadata:")
+                for (key, value) in metadata.sorted(by: { $0.key < $1.key }) {
+                    print("  • \(key): \(value)")
+                }
+            }
+        }
+#endif
+    }
+    
+    public func info(_ message: String, metadata: [String: Any] = [:], file: String = #file, function: String = #function, line: UInt = #line) {
+        log(.info, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
+    public func debug(_ message: String, metadata: [String: Any] = [:], file: String = #file, function: String = #function, line: UInt = #line) {
+        log(.debug, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
+    public func warning(_ message: String, metadata: [String: Any] = [:], file: String = #file, function: String = #function, line: UInt = #line) {
+        log(.warning, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
+    public func error(_ message: String, metadata: [String: Any] = [:], file: String = #file, function: String = #function, line: UInt = #line) {
+        log(.error, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
+    public func critical(_ message: String, metadata: [String: Any] = [:], file: String = #file, function: String = #function, line: UInt = #line) {
+        log(.critical, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
+}
+
+// MARK: - DateFormatter Extension
+extension DateFormatter {
+    static let logTimestamp: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter
+    }()
+}

--- a/Projects/Data/BaseData/Sources/Plugin/Logger/MoyaLoggerPlugin.swift
+++ b/Projects/Data/BaseData/Sources/Plugin/Logger/MoyaLoggerPlugin.swift
@@ -1,0 +1,136 @@
+//
+//  MoyaLoggerPlugin.swift
+//  BaseData
+//
+//  Created by 선민재 on 3/30/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+final class MoyaLoggerPlugin: PluginType {
+    
+    private let logger: LoggerSystem
+    
+    init(logger: LoggerSystem? = nil) {
+        self.logger = logger ?? LoggerSystem(
+            category: "Network",
+            useOSLog: true,
+            useConsole: true,
+            showMetadata: true,
+            showSourceInfo: false
+        )
+    }
+    
+    func willSend(_ request: Moya.RequestType, target: TargetType) {
+        let url = request.request?.url?.absoluteString ?? "Unknown URL"
+        let httpMethod = request.request?.httpMethod ?? "Unknown Method"
+        let headers = request.request?.allHTTPHeaderFields ?? [:]
+        
+        var metaData: [String: Any] = [
+            "🎯 target": String(describing: target),
+            "🔧 method": httpMethod,
+            "🌐 url": url
+            /// 헤더 정보 주석 처리
+//            "📝 requestHeaders": headers
+        ]
+        
+        // 요청 바디가 있는 경우 로깅
+        if let httpBody = request.request?.httpBody,
+           let bodyString = String(data: httpBody, encoding: .utf8) {
+            metaData["requestBody"] = bodyString
+        }
+        
+        logger.debug("🚀 네트워크 요청 시작 \n🌐 url: \(url)", metadata: metaData)
+    }
+    
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        switch result {
+        case let .success(response):
+            onSuceed(response, target: target)
+        case let .failure(error):
+            onFail(error, target: target)
+        }
+    }
+    
+    func onSuceed(_ response: Response, target: TargetType) {
+        let url = response.request?.url?.absoluteString ?? "Unknown URL"
+        let responseHeaders = response.response?.allHeaderFields ?? [:]
+        let isSuccess = 200..<300 ~= response.statusCode
+        
+        var metaData: [String: Any] = [
+            "🎯 target": String(describing: target),
+            "🌐 url": url,
+            "📊 statusCode": response.statusCode
+            /// 헤더 정보 주석 처리
+//            "📝 responseHeaders": responseHeaders
+        ]
+        
+        // 응답 데이터 출력
+        if let jsonObject = try? JSONSerialization.jsonObject(with: response.data, options: []) {
+            if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted, .sortedKeys]),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                let finalJson = jsonString.count > 1000 ?
+                String(jsonString.prefix(1000)) + "\n..." : jsonString
+                metaData["responseBody"] = finalJson
+            } else {
+                metaData["responseBody"] = jsonObject
+            }
+        } else if let responseString = String(data: response.data, encoding: .utf8) {
+            let truncatedString = responseString.count > 500 ?
+            String(responseString.prefix(500)) + "..." : responseString
+            metaData["responseBody"] = truncatedString
+        } else {
+            let dataDescription = response.data.count > 100 ?
+            "Binary data (\(response.data.count) bytes)" : response.data.description
+            metaData["responseBody"] = dataDescription
+        }
+        
+        if isSuccess {
+            logger.info("✅ 네트워크 요청 성공\n🌐 url: \(url)", metadata: metaData)
+        } else {
+            logger.warning("⚠️ 네트워크 요청 완료 (비정상 상태)\n🌐 url: \(url)", metadata: metaData)
+        }
+    }
+    
+    func onFail(_ error: MoyaError, target: TargetType) {
+        let url = error.response?.request?.url?.absoluteString ?? "Unknown URL"
+        let errorHeaders = error.response?.response?.allHeaderFields ?? [:]
+        let statusCode = error.response?.statusCode
+        
+        var metaData: [String: Any] = [
+            "🎯 target": String(describing: target),
+            "🌐 url": url,
+            "💥 error": error.localizedDescription,
+            "🔢 errorCode": error.errorCode,
+            "📊 statusCode": statusCode ?? "N/A"
+//            "📝 errorHeaders": errorHeaders
+        ]
+        
+        // 에러 응답 바디 추가
+        if let errorResponse = error.response,
+           let errorData = String(data: errorResponse.data, encoding: .utf8) {
+            if let jsonObject = try? JSONSerialization.jsonObject(with: errorResponse.data, options: []),
+               let jsonData = try? JSONSerialization.data(
+                withJSONObject: jsonObject,
+                options: [.prettyPrinted, .sortedKeys]
+               ),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                
+                let truncatedError = jsonString.count > 500 ? String(jsonString.prefix(500)) + "\n..." : jsonString
+                metaData.updateValue(truncatedError, forKey: "errorResponse")
+            } else {
+                let truncatedError = errorData.count > 300 ? String(errorData.prefix(300)) + "..." : errorData
+                metaData.updateValue(truncatedError, forKey: "errorResponse")
+            }
+        } else if let errorResponse = error.response, !errorResponse.data.isEmpty {
+            let dataDescription = errorResponse.data.count > 100 ?
+                "Binary error data (\(errorResponse.data.count) bytes)" : errorResponse.data.description
+            metaData.updateValue(dataDescription, forKey: "errorResponse")
+        }
+
+        logger.error("❌ 네트워크 요청 실패\n🌐 url: \(url)", metadata: metaData)
+    }
+    
+}

--- a/Projects/Data/BaseData/Sources/Provider/DefaultProvider.swift
+++ b/Projects/Data/BaseData/Sources/Provider/DefaultProvider.swift
@@ -27,11 +27,12 @@ public final class DefaultProvider<T: TargetType>: MoyaProvider<T> {
         
         let interceptor: RequestInterceptor = AuthorizationInterceptor.shared
         let authorizationPlugin: PluginType = AuthorizationPlugin.shared
+        let loggerPlugin: MoyaLoggerPlugin = .init()
 
         super.init(
             requestClosure: requestClosure,
             session: Session(interceptor: interceptor),
-            plugins: [authorizationPlugin]
+            plugins: [authorizationPlugin, loggerPlugin]
         )
     }
 }

--- a/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
+++ b/Projects/Domain/AuthDomain/Sources/Repository/AuthRepository.swift
@@ -9,4 +9,5 @@
 public protocol AuthRepository {
     func fetchSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws
     func hasAccessToken() -> Bool
+    func logout() async throws
 }

--- a/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
+++ b/Projects/Domain/AuthDomain/Sources/UseCase/AuthUseCase.swift
@@ -15,6 +15,7 @@ public enum AutoSignInError: Error {
 public protocol AuthUseCase {
     func executeSignIn(idToken: String, authorizationCode: String?, type: SignInType) async throws -> Bool
     func executeAutoSignIn() async throws -> Bool
+    func executeLogout() async throws
 }
 
 public final class DefaultAuthUseCase: AuthUseCase {
@@ -38,7 +39,7 @@ public final class DefaultAuthUseCase: AuthUseCase {
     }
 
     public func executeAutoSignIn() async throws -> Bool {
-                
+
         guard authRepository.hasAccessToken() else {
             throw AutoSignInError.noToken
         }
@@ -46,5 +47,9 @@ public final class DefaultAuthUseCase: AuthUseCase {
         let userInfo = try await userRepository.fetchUserInfo()
 
         return userInfo.isOnboarding
+    }
+
+    public func executeLogout() async throws {
+        try await authRepository.logout()
     }
 }

--- a/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
+++ b/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
@@ -115,6 +115,11 @@ extension AppCoordinator: ProfileCoordinatorDelegate {
         navigationController.popViewController(animated: true)
         profileCoordinator = nil
     }
+
+    public func profileCoordinatorDidLogout() {
+        profileCoordinator = nil
+        moveToLoginCoordinator()
+    }
 }
 
 extension AppCoordinator: HomeCoordinatorDelegate {

--- a/Projects/Feature/AuthFeature/Sources/DIContainer/LoginDIContainer.swift
+++ b/Projects/Feature/AuthFeature/Sources/DIContainer/LoginDIContainer.swift
@@ -35,7 +35,8 @@ public final class LoginDIContainer {
     private func makeAuthRepository() -> AuthRepository {
         return DefaultAuthRepository(
             authProvider: makeAuthProvdier(),
-            keyChainStorage: makeKeyChainStorage()
+            keyChainStorage: makeKeyChainStorage(),
+            userDefaultStorage: makeUserDefaultStorage()
         )
     }
     

--- a/Projects/Feature/ProfileFeature/Project.swift
+++ b/Projects/Feature/ProfileFeature/Project.swift
@@ -14,6 +14,8 @@ let project = Project.makeModule(
     dependencies: [
         .Presentation.ProfilePresentation,
         .Data.BaseData,
-        .Domain.BaseDomain
+        .Data.AuthData,
+        .Domain.BaseDomain,
+        .Domain.AuthDomain
     ]
 )

--- a/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
+++ b/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
@@ -12,6 +12,7 @@ import ProfilePresentation
 
 public protocol ProfileCoordinatorDelegate: AnyObject {
     func moveToBack()
+    func profileCoordinatorDidLogout()
 }
 
 public final class ProfileCoordinator {
@@ -76,7 +77,7 @@ extension ProfileCoordinator: ProfileViewModelDelegate, EditProfileViewModelDele
     }
 
     public func moveToLogout() {
-        // TODO: Handle logout
+        delegate?.profileCoordinatorDidLogout()
     }
 
     public func moveToWithdrawal() {

--- a/Projects/Feature/ProfileFeature/Sources/DIContainer/ProfileDIContainer.swift
+++ b/Projects/Feature/ProfileFeature/Sources/DIContainer/ProfileDIContainer.swift
@@ -11,6 +11,8 @@ import Foundation
 import ProfilePresentation
 import BaseData
 import BaseDomain
+import AuthData
+import AuthDomain
 
 public final class ProfileDIContainer {
     public init() {}
@@ -23,6 +25,10 @@ public final class ProfileDIContainer {
         return DefaultUserDefaultStorage()
     }
 
+    private func makeKeyChainStorage() -> KeyChainStorage {
+        return DefaultKeyChainStorage()
+    }
+
     private func makeUserRepository() -> UserRepository {
         return DefaultUserRepository(
             provider: makeUserProvider(),
@@ -32,6 +38,25 @@ public final class ProfileDIContainer {
 
     private func makeUserUseCase() -> UserUseCase {
         return DefaultUserUseCase(userRepository: makeUserRepository())
+    }
+
+    private func makeAuthProvider() -> DefaultProvider<AuthTargetType> {
+        return DefaultProvider<AuthTargetType>()
+    }
+
+    private func makeAuthRepository() -> AuthRepository {
+        return DefaultAuthRepository(
+            authProvider: makeAuthProvider(),
+            keyChainStorage: makeKeyChainStorage(),
+            userDefaultStorage: makeUserDefaultStorage()
+        )
+    }
+
+    private func makeAuthUseCase() -> AuthUseCase {
+        return DefaultAuthUseCase(
+            authRepository: makeAuthRepository(),
+            userRepository: makeUserRepository()
+        )
     }
 
     public func makeProfileViewModel() -> ProfileViewModel {
@@ -62,7 +87,7 @@ public final class ProfileDIContainer {
     }
 
     public func makeSettingsViewModel() -> SettingsViewModel {
-        return SettingsViewModel()
+        return SettingsViewModel(authUseCase: makeAuthUseCase())
     }
 
     public func makeSettingsViewController(

--- a/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
+++ b/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
@@ -35,7 +35,8 @@ public final class SplashDIContainer {
     private func makeAuthRepository() -> AuthRepository {
         return DefaultAuthRepository(
             authProvider: makeAuthProvider(),
-            keyChainStorage: makeKeyChainStorage()
+            keyChainStorage: makeKeyChainStorage(),
+            userDefaultStorage: makeUserDefaultStorage()
         )
     }
 

--- a/Projects/Presentation/ProfilePresentation/Project.swift
+++ b/Projects/Presentation/ProfilePresentation/Project.swift
@@ -14,7 +14,8 @@ let project = Project.makeModule(
     dependencies: [
         .ThridPartyLib.ThridPartyLib,
         .Shared.DesignSystem,
-        .Domain.BaseDomain
+        .Domain.BaseDomain,
+        .Domain.AuthDomain
     ],
     resources: ["Resources/**"]
 )

--- a/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
@@ -9,6 +9,8 @@
 import RxSwift
 import RxCocoa
 
+import AuthDomain
+
 public protocol SettingsViewModelDelegate: AnyObject {
     func moveToBack()
     func moveToTermsOfService()
@@ -18,8 +20,12 @@ public protocol SettingsViewModelDelegate: AnyObject {
 
 public final class SettingsViewModel {
     private let disposeBag: DisposeBag = DisposeBag()
+    private let authUseCase: AuthUseCase
     public weak var delegate: SettingsViewModelDelegate?
-    public init() {}
+
+    public init(authUseCase: AuthUseCase) {
+        self.authUseCase = authUseCase
+    }
 
     struct Input {
         let backButtonDidTap: ControlEvent<Void>
@@ -48,7 +54,7 @@ public final class SettingsViewModel {
         input.logoutButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
-                self.delegate?.moveToLogout()
+                self.requestSignOut()
             })
             .disposed(by: disposeBag)
 
@@ -60,5 +66,16 @@ public final class SettingsViewModel {
             .disposed(by: disposeBag)
 
         return Output()
+    }
+}
+
+extension SettingsViewModel {
+    private func requestSignOut() {
+        Task {
+            try? await self.authUseCase.executeLogout()
+            await MainActor.run {
+                self.delegate?.moveToLogout()
+            }
+        }
     }
 }


### PR DESCRIPTION
## 변경 사항

### 로그아웃 플로우 구현
- `AuthTargetType` — `DELETE /auth/logout` 엔드포인트 추가 (Authorization 헤더 포함)
- `AuthRepository` / `DefaultAuthRepository` — `logout()` 구현
  - API 성공 여부와 관계없이 Keychain(`accessToken`, `refreshToken`) 및 UserDefaults(`userId`) 삭제
- `AuthUseCase` / `DefaultAuthUseCase` — `executeLogout()` 추가
- `SettingsViewModel` — `AuthUseCase` 의존성 주입, 로그아웃 바인딩 추가
- `ProfileDIContainer` — `AuthUseCase` 팩토리 메서드 추가 및 `SettingsViewModel` 의존성 주입
- `ProfileCoordinator` — `ProfileCoordinatorDelegate` 추가, `moveToLogout()` 구현
- `AppCoordinator` — `profileCoordinatorDidLogout()` 채택 후 `moveToLoginCoordinator()` 호출
- `LoginDIContainer` / `SplashDIContainer` — `DefaultAuthRepository` 초기화 시 `userDefaultStorage` 주입

### Moya Logger 플러그인 추가
- `LoggerSystem.swift` — OSLog 기반 로거 시스템 구현
- `MoyaLoggerPlugin.swift` — Moya 요청/응답 로깅 플러그인 구현
- `DefaultProvider` — Logger 플러그인 적용

## 테스트 방법

- [ ] 설정 화면에서 로그아웃 버튼 탭 → 다이얼로그 확인
- [ ] 다이얼로그 로그아웃 확인 → API 호출 후 LoginViewController로 이동 확인
- [ ] 로그아웃 후 앱 재실행 시 자동 로그인 없이 로그인 화면 진입 확인
- [ ] 네트워크 차단 상태에서 로그아웃 시도 → 로컬 데이터 삭제 후 Login 이동 확인
- [ ] Xcode 콘솔에서 Moya 요청/응답 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)