### PR TITLE
Feature: 회원탈퇴 API 연동 및 다이얼로그 구현

### DIFF
--- a/Projects/Data/BaseData/Sources/Repository/DefaultUserRepository.swift
+++ b/Projects/Data/BaseData/Sources/Repository/DefaultUserRepository.swift
@@ -12,16 +12,19 @@ import BaseDomain
 import Foundation
 
 public final class DefaultUserRepository: UserRepository {
-    
+
     private let provider: DefaultProvider<UserTargetType>
     private let userDefaultStorage: UserDefaultStorage
-    
+    private let keyChainStorage: KeyChainStorage
+
     public init(
         provider: DefaultProvider<UserTargetType>,
-        userDefaultStorage: UserDefaultStorage
+        userDefaultStorage: UserDefaultStorage,
+        keyChainStorage: KeyChainStorage
     ) {
         self.provider = provider
         self.userDefaultStorage = userDefaultStorage
+        self.keyChainStorage = keyChainStorage
     }
     
     public func fetchUserInfo() async throws -> UserInfoEntity {
@@ -59,5 +62,12 @@ public final class DefaultUserRepository: UserRepository {
             result: result,
             errorType: EditProfileError.self
         )
+    }
+
+    public func deleteAccount() async throws {
+        _ = await provider.request(.deleteAccount)
+        _ = keyChainStorage.delete(key: .accessToken)
+        _ = keyChainStorage.delete(key: .refreshToken)
+        userDefaultStorage.remove(forKey: .userId)
     }
 }

--- a/Projects/Data/BaseData/Sources/TargetType/UserTargetType.swift
+++ b/Projects/Data/BaseData/Sources/TargetType/UserTargetType.swift
@@ -13,12 +13,13 @@ public enum UserTargetType {
     case userInfo
     case uploadProfileImage(userId: Int, file: String)
     case editProfile(nickname: String, profileImage: Data?)
+    case deleteAccount
 }
 
 extension UserTargetType: BaseTargetType {
     public var path: String {
         switch self {
-        case .userInfo, .editProfile:
+        case .userInfo, .editProfile, .deleteAccount:
             return "/users/me"
         case .uploadProfileImage:
             return "/s3/upload/profile-image"
@@ -33,6 +34,8 @@ extension UserTargetType: BaseTargetType {
             return .post
         case .editProfile:
             return .put
+        case .deleteAccount:
+            return .delete
         }
     }
 
@@ -46,6 +49,8 @@ extension UserTargetType: BaseTargetType {
                 bodyEncoding: JSONEncoding.default,
                 urlParameters: ["userId": userId]
             )
+        case .deleteAccount:
+            return .requestPlain
         case .editProfile(let nickname, let profileImage):
             if let imageData = profileImage {
                 let multipartData = [MultipartFormData(

--- a/Projects/Domain/BaseDomain/Sources/Repository/UserRepository.swift
+++ b/Projects/Domain/BaseDomain/Sources/Repository/UserRepository.swift
@@ -12,4 +12,5 @@ public protocol UserRepository {
     func fetchUserInfo() async throws -> UserInfoEntity
     func uploadProfileImage(file: String) async throws -> String
     func editProfile(nickname: String, profileImage: Data?) async throws
+    func deleteAccount() async throws
 }

--- a/Projects/Domain/BaseDomain/Sources/UseCase/UserUseCase.swift
+++ b/Projects/Domain/BaseDomain/Sources/UseCase/UserUseCase.swift
@@ -11,6 +11,7 @@ import Foundation
 public protocol UserUseCase {
     func fetchUserInfo() async throws -> UserInfoEntity
     func editProfile(nickname: String, profileImage: Data?) async throws
+    func deleteAccount() async throws
 }
 
 public final class DefaultUserUseCase: UserUseCase {
@@ -26,5 +27,9 @@ public final class DefaultUserUseCase: UserUseCase {
 
     public func editProfile(nickname: String, profileImage: Data?) async throws {
         try await userRepository.editProfile(nickname: nickname, profileImage: profileImage)
+    }
+
+    public func deleteAccount() async throws {
+        try await userRepository.deleteAccount()
     }
 }

--- a/Projects/Feature/AuthFeature/Sources/DIContainer/LoginDIContainer.swift
+++ b/Projects/Feature/AuthFeature/Sources/DIContainer/LoginDIContainer.swift
@@ -43,7 +43,8 @@ public final class LoginDIContainer {
     private func makeUserRepository() -> UserRepository {
         return DefaultUserRepository(
             provider: makeUserProvdier(),
-            userDefaultStorage: makeUserDefaultStorage()
+            userDefaultStorage: makeUserDefaultStorage(),
+            keyChainStorage: makeKeyChainStorage()
         )
     }
     

--- a/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
+++ b/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
@@ -81,6 +81,6 @@ extension ProfileCoordinator: ProfileViewModelDelegate, EditProfileViewModelDele
     }
 
     public func moveToWithdrawal() {
-        // TODO: Handle withdrawal
+        delegate?.profileCoordinatorDidLogout()
     }
 }

--- a/Projects/Feature/ProfileFeature/Sources/DIContainer/ProfileDIContainer.swift
+++ b/Projects/Feature/ProfileFeature/Sources/DIContainer/ProfileDIContainer.swift
@@ -32,7 +32,8 @@ public final class ProfileDIContainer {
     private func makeUserRepository() -> UserRepository {
         return DefaultUserRepository(
             provider: makeUserProvider(),
-            userDefaultStorage: makeUserDefaultStorage()
+            userDefaultStorage: makeUserDefaultStorage(),
+            keyChainStorage: makeKeyChainStorage()
         )
     }
 
@@ -87,7 +88,10 @@ public final class ProfileDIContainer {
     }
 
     public func makeSettingsViewModel() -> SettingsViewModel {
-        return SettingsViewModel(authUseCase: makeAuthUseCase())
+        return SettingsViewModel(
+            authUseCase: makeAuthUseCase(),
+            userUseCase: makeUserUseCase()
+        )
     }
 
     public func makeSettingsViewController(

--- a/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
+++ b/Projects/Feature/SplashFeature/Sources/DIContainer/SplashDIContainer.swift
@@ -43,7 +43,8 @@ public final class SplashDIContainer {
     private func makeUserRepository() -> UserRepository {
         return DefaultUserRepository(
             provider: makeUserProvider(),
-            userDefaultStorage: makeUserDefaultStorage()
+            userDefaultStorage: makeUserDefaultStorage(),
+            keyChainStorage: makeKeyChainStorage()
         )
     }
 

--- a/Projects/Presentation/ProfilePresentation/Sources/Controller/SettingsViewController.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/Controller/SettingsViewController.swift
@@ -18,6 +18,7 @@ public final class SettingsViewController: UIViewController {
     private let viewModel: SettingsViewModel
     
     private let logoutButtonDidTap: PublishRelay<Void> = .init()
+    private let withdrawalConfirmDidTap: PublishRelay<Void> = .init()
     
     private let navigationView: MemorySealNavigationView = {
         let view = MemorySealNavigationView()
@@ -97,7 +98,7 @@ extension SettingsViewController {
             backButtonDidTap: navigationView.backButtonDidTap,
             termsOfServiceDidTap: termsOfServiceButton.rx.tap,
             logoutButtonDidTap: logoutButtonDidTap.asObservable(),
-            withdrawalDidTap: withdrawalButton.rx.tap
+            withdrawalDidTap: withdrawalConfirmDidTap.asObservable()
         )
         let _ = viewModel.translation(input)
     }
@@ -106,6 +107,12 @@ extension SettingsViewController {
         logoutButton.rx.tap
             .subscribe(with: self, onNext: { (self, _) in
                 self.showLogoutDiaLogView()
+            })
+            .disposed(by: disposeBag)
+
+        withdrawalButton.rx.tap
+            .subscribe(with: self, onNext: { (self, _) in
+                self.showWithdrawalDialogView()
             })
             .disposed(by: disposeBag)
     }
@@ -133,7 +140,29 @@ extension SettingsViewController {
             })
             .disposed(by: disposeBag)
     }
-    
+
+    private func showWithdrawalDialogView() {
+        let dialog = DialogView.show(
+            on: view,
+            title: "회원탈퇴",
+            message: "메실 회원을 탈퇴하시겠습니까?\n티켓에 저장된 내용은 삭제되지 않습니다.",
+            cancelTitle: "취소",
+            confirmTitle: "탈퇴"
+        )
+
+        dialog.confirmButtonDidTap
+            .subscribe(with: self, onNext: { (self, _) in
+                self.withdrawalConfirmDidTap.accept(())
+            })
+            .disposed(by: disposeBag)
+
+        dialog.cancelButtonDidTap
+            .subscribe(with: self, onNext: { (self, _) in
+                dialog.dismiss()
+            })
+            .disposed(by: disposeBag)
+    }
+
     private func addSubviews() {
         view.addSubview(navigationView)
         view.addSubview(rowsContainerView)

--- a/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
@@ -74,19 +74,21 @@ public final class SettingsViewModel {
 
 extension SettingsViewModel {
     private func requestSignOut() {
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             try? await self.authUseCase.executeLogout()
-            await MainActor.run {
-                self.delegate?.moveToLogout()
+            await MainActor.run { [weak self] in
+                self?.delegate?.moveToLogout()
             }
         }
     }
 
     private func requestDeleteAccount() {
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             try? await self.userUseCase.deleteAccount()
-            await MainActor.run {
-                self.delegate?.moveToWithdrawal()
+            await MainActor.run { [weak self] in
+                self?.delegate?.moveToWithdrawal()
             }
         }
     }

--- a/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/ViewModel/SettingsViewModel.swift
@@ -10,6 +10,7 @@ import RxSwift
 import RxCocoa
 
 import AuthDomain
+import BaseDomain
 
 public protocol SettingsViewModelDelegate: AnyObject {
     func moveToBack()
@@ -21,17 +22,19 @@ public protocol SettingsViewModelDelegate: AnyObject {
 public final class SettingsViewModel {
     private let disposeBag: DisposeBag = DisposeBag()
     private let authUseCase: AuthUseCase
+    private let userUseCase: UserUseCase
     public weak var delegate: SettingsViewModelDelegate?
 
-    public init(authUseCase: AuthUseCase) {
+    public init(authUseCase: AuthUseCase, userUseCase: UserUseCase) {
         self.authUseCase = authUseCase
+        self.userUseCase = userUseCase
     }
 
     struct Input {
         let backButtonDidTap: ControlEvent<Void>
         let termsOfServiceDidTap: ControlEvent<Void>
         let logoutButtonDidTap: Observable<Void>
-        let withdrawalDidTap: ControlEvent<Void>
+        let withdrawalDidTap: Observable<Void>
     }
 
     struct Output {}
@@ -61,7 +64,7 @@ public final class SettingsViewModel {
         input.withdrawalDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
-                self.delegate?.moveToWithdrawal()
+                self.requestDeleteAccount()
             })
             .disposed(by: disposeBag)
 
@@ -75,6 +78,15 @@ extension SettingsViewModel {
             try? await self.authUseCase.executeLogout()
             await MainActor.run {
                 self.delegate?.moveToLogout()
+            }
+        }
+    }
+
+    private func requestDeleteAccount() {
+        Task {
+            try? await self.userUseCase.deleteAccount()
+            await MainActor.run {
+                self.delegate?.moveToWithdrawal()
             }
         }
     }


### PR DESCRIPTION
## 변경 사항

### 회원탈퇴 플로우 구현
- `UserTargetType` — `DELETE /users/me` 엔드포인트 추가
- `UserRepository` / `DefaultUserRepository` — `deleteAccount()` 구현
  - API 성공 여부와 관계없이 Keychain(`accessToken`, `refreshToken`) 및 UserDefaults(`userId`) 삭제
- `UserUseCase` / `DefaultUserUseCase` — `deleteAccount()` 추가
- `SettingsViewModel` — `UserUseCase` 의존성 주입, 회원탈퇴 바인딩 추가
- `ProfileDIContainer` — `UserUseCase` 팩토리 메서드 추가 및 `SettingsViewModel` 의존성 주입
- `ProfileCoordinator` — `moveToWithdrawal()` TODO 구현 (`profileCoordinatorDidLogout` 재사용)

### 회원탈퇴 다이얼로그 (Figma 디자인 반영)
- `SettingsViewController` — 회원탈퇴 버튼 탭 시 다이얼로그 표시
  - 제목: "회원탈퇴"
  - 메시지: "메실 회원을 탈퇴하시겠습니까?\n티켓에 저장된 내용은 삭제되지 않습니다."
  - 취소 버튼 / 탈퇴 버튼 (green primaryNormal)
  - 확인 후 `withdrawalConfirmDidTap` relay를 통해 API 호출

### 버그 수정
- `SettingsViewModel` — `Task` 블록 내 `self` 강한 캡처로 인한 메모리 누수 수정 (`[weak self]` 적용)

## 테스트 방법

- [ ] 설정 화면에서 회원탈퇴 버튼 탭 → 다이얼로그 표시 확인
- [ ] 다이얼로그 취소 버튼 탭 → 다이얼로그 닫힘 확인
- [ ] 다이얼로그 탈퇴 버튼 탭 → API 호출 후 LoginViewController 이동 확인
- [ ] 탈퇴 후 앱 재실행 시 자동 로그인 없이 로그인 화면 진입 확인
- [ ] 네트워크 차단 상태에서 탈퇴 시도 → 로컬 데이터 삭제 후 Login 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)