### PR TITLE
Fix: editProfile nickname 옵셔널 처리 및 이미지/닉네임 단독 수정 지원

### DIFF
--- a/Projects/Data/BaseData/Sources/Repository/DefaultUserRepository.swift
+++ b/Projects/Data/BaseData/Sources/Repository/DefaultUserRepository.swift
@@ -55,8 +55,11 @@ public final class DefaultUserRepository: UserRepository {
         return responseDTO.profileImageUrl
     }
 
-    public func editProfile(nickname: String, profileImage: Data?) async throws {
+    public func editProfile(nickname: String?, profileImage: Data?) async throws {
         let result = await provider.request(.editProfile(nickname: nickname, profileImage: profileImage))
+        
+        print("profileImage", profileImage)
+        print("nickname", nickname)
 
         try ResultHandler.handleResult(
             result: result,

--- a/Projects/Data/BaseData/Sources/TargetType/UserTargetType.swift
+++ b/Projects/Data/BaseData/Sources/TargetType/UserTargetType.swift
@@ -12,7 +12,7 @@ import Moya
 public enum UserTargetType {
     case userInfo
     case uploadProfileImage(userId: Int, file: String)
-    case editProfile(nickname: String, profileImage: Data?)
+    case editProfile(nickname: String?, profileImage: Data?)
     case deleteAccount
 }
 
@@ -59,11 +59,18 @@ extension UserTargetType: BaseTargetType {
                     fileName: "profile.jpg",
                     mimeType: "image/jpeg"
                 )]
-                return .uploadCompositeMultipart(multipartData, urlParameters: ["nickname": nickname])
+                return .uploadCompositeMultipart(
+                    multipartData,
+                    urlParameters: nickname.map { ["nickname": $0] } ?? [:]
+                )
             } else {
-                return .requestParameters(
-                    parameters: ["nickname": nickname],
-                    encoding: URLEncoding.queryString
+                let emptyImagePart = MultipartFormData(
+                    provider: .data(Data()),
+                    name: "profileImage"
+                )
+                return .uploadCompositeMultipart(
+                    [emptyImagePart],
+                    urlParameters: nickname.map { ["nickname": $0] } ?? [:]
                 )
             }
         }

--- a/Projects/Domain/BaseDomain/Sources/Repository/UserRepository.swift
+++ b/Projects/Domain/BaseDomain/Sources/Repository/UserRepository.swift
@@ -11,6 +11,6 @@ import Foundation
 public protocol UserRepository {
     func fetchUserInfo() async throws -> UserInfoEntity
     func uploadProfileImage(file: String) async throws -> String
-    func editProfile(nickname: String, profileImage: Data?) async throws
+    func editProfile(nickname: String?, profileImage: Data?) async throws
     func deleteAccount() async throws
 }

--- a/Projects/Domain/BaseDomain/Sources/UseCase/UserUseCase.swift
+++ b/Projects/Domain/BaseDomain/Sources/UseCase/UserUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public protocol UserUseCase {
     func fetchUserInfo() async throws -> UserInfoEntity
-    func editProfile(nickname: String, profileImage: Data?) async throws
+    func editProfile(nickname: String?, profileImage: Data?) async throws
     func deleteAccount() async throws
 }
 
@@ -25,7 +25,7 @@ public final class DefaultUserUseCase: UserUseCase {
         return try await userRepository.fetchUserInfo()
     }
 
-    public func editProfile(nickname: String, profileImage: Data?) async throws {
+    public func editProfile(nickname: String?, profileImage: Data?) async throws {
         try await userRepository.editProfile(nickname: nickname, profileImage: profileImage)
     }
 

--- a/Projects/Presentation/ProfilePresentation/Sources/Controller/EditProfileViewController.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/Controller/EditProfileViewController.swift
@@ -235,24 +235,38 @@ extension EditProfileViewController {
             })
             .disposed(by: disposeBag)
 
-        nicknameTextField.rx.controlEvent(.editingChanged)
+        let nicknameValidation = nicknameTextField.rx.controlEvent(.editingChanged)
             .withLatestFrom(nicknameTextField.rx.text.orEmpty)
             .distinctUntilChanged()
-            .scan((validatedText: "", isLimitExceeded: false)) { previous, newText in
+            .scan((validatedText: viewModel.nickname, isLimitExceeded: false)) { previous, newText in
                 guard newText.count <= 16 else {
                     return (previous.validatedText, true)
                 }
                 return (newText, false)
             }
+            .share(replay: 1)
+
+        nicknameValidation
             .withUnretained(self)
             .bind { (self, result) in
                 let isInvalid = result.validatedText.isEmpty || result.isLimitExceeded
-                let saveButtonIsInvalid = result.validatedText.isEmpty
                 self.nicknameHelperLabel.isHidden = !isInvalid
-                self.saveButton.isEnabled = !saveButtonIsInvalid
-                
                 self.nicknameTextField.text = result.validatedText
             }
+            .disposed(by: disposeBag)
+
+        let nicknameChanged = nicknameValidation
+            .map {
+                $0.validatedText != self.viewModel.nickname && !$0.validatedText.isEmpty
+            }
+            .startWith(false)
+
+        let imageSelected = selectedProfileImage
+            .map { $0 != nil }
+
+        Observable.combineLatest(nicknameChanged, imageSelected)
+            .map { $0 || $1 }
+            .bind(to: saveButton.rx.isEnabled)
             .disposed(by: disposeBag)
     }
 

--- a/Projects/Presentation/ProfilePresentation/Sources/ViewModel/EditProfileViewModel.swift
+++ b/Projects/Presentation/ProfilePresentation/Sources/ViewModel/EditProfileViewModel.swift
@@ -50,13 +50,14 @@ public final class EditProfileViewModel {
 
         input.saveButtonDidTap
             .withLatestFrom(Observable.combineLatest(
-                input.nicknameText.map { $0 ?? "" },
+                input.nicknameText.asObservable(),
                 input.selectedProfileImage.asObservable()
             ))
             .withUnretained(self)
             .subscribe(onNext: { (self, args) in
-                let (nickname, imageData) = args
-                
+                let (nicknameText, imageData) = args
+                let nickname: String? = (nicknameText != self.nickname) ? nicknameText : nil
+
                 self.editUserProfileInfo(nickname: nickname, profileImage: imageData)
             })
             .disposed(by: disposeBag)
@@ -66,7 +67,7 @@ public final class EditProfileViewModel {
 }
 
 extension EditProfileViewModel {
-    private func editUserProfileInfo(nickname: String, profileImage: Data?) {
+    private func editUserProfileInfo(nickname: String?, profileImage: Data?) {
         Task {
             do {
                 try await self.userUseCase.editProfile(


### PR DESCRIPTION
## 변경 사항

- `editProfile` nickname 파라미터 `String` → `String?` 변경 (UserRepository, UserUseCase, DefaultUserRepository, UserTargetType, EditProfileViewModel 전 레이어)
- 이미지 없는 경우 빈 `profileImage` 파트를 포함한 `multipart/form-data`로 전송하여 서버 `Content-Type is not supported (500)` 오류 수정
- 닉네임 미변경 시 `nil` 전달하여 불필요한 nickname 쿼리 파라미터 제외
- 이미지만 변경해도 저장 버튼 활성화 (`nicknameChanged.startWith(false)` 추가)

## 테스트 방법

- [ ] 닉네임만 변경 후 저장 → 정상 저장 확인
- [ ] 이미지만 변경 후 저장 → 저장 버튼 활성화 및 정상 저장 확인
- [ ] 닉네임 + 이미지 동시 변경 후 저장 → 정상 저장 확인
- [ ] 아무것도 변경하지 않으면 저장 버튼 비활성화 확인