### PR TITLE
Feature: 참여코드 합류API 연동

### DIFF
--- a/Projects/Data/BaseData/Sources/Repository/DefaultTimeCapsuleRepository.swift
+++ b/Projects/Data/BaseData/Sources/Repository/DefaultTimeCapsuleRepository.swift
@@ -30,6 +30,11 @@ public final class DefaultTimeCapsuleRepository: TimeCapsuleRepository {
         return responseDTOs.map { $0.toDomain }
     }
 
+    public func joinRequest(code: String) async throws {
+        let result = await provider.request(.joinRequest(code: code))
+        try ResultHandler.handleResult(result: result, errorType: TimeCapsuleError.self)
+    }
+
     public func inviteToTimeCapsule(capsuleId: Int) async throws -> String {
         let result = await provider.request(.inviteToTimeCapsule(capsuleId: capsuleId))
 

--- a/Projects/Data/BaseData/Sources/ResponseDTO/ErrorResponseDTO.swift
+++ b/Projects/Data/BaseData/Sources/ResponseDTO/ErrorResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  ErrorResponseDTO.swift
+//  BaseData
+//
+//  Created by 선민재 on 4/6/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+struct ErrorResponseDTO: Decodable {
+    let status: String?
+    let error: String?
+    let message: String?
+    let path: String?
+
+    var toDomain: ErrorResponseEntity {
+        return .init(
+            status: status ?? "",
+            error: error ?? "",
+            message: message ?? "",
+            path: path ?? ""
+        )
+    }
+}

--- a/Projects/Data/BaseData/Sources/ResultHandler/ResultHandler.swift
+++ b/Projects/Data/BaseData/Sources/ResultHandler/ResultHandler.swift
@@ -23,13 +23,18 @@ public final class ResultHandler {
             case 200..<300:
                 return try response.map(responseType, using: JSONDecoder())
             default:
-                throw Error.init(statusCode: response.statusCode)
+                let errorResponseDTO = try response.map(ErrorResponseDTO.self, using: JSONDecoder())
+                throw Error.init(errorResponse: errorResponseDTO.toDomain)
             }
         case .failure(let error):
+            guard let response = error.response else { throw error }
+            if let errorResponseDTO = try? response.map(ErrorResponseDTO.self, using: JSONDecoder()) {
+                throw Error.init(errorResponse: errorResponseDTO.toDomain)
+            }
             throw error
         }
     }
-    
+
     public static func handleResult<Error: DomainError>(
         result: Result<Response, MoyaError>,
         errorType: Error.Type
@@ -40,9 +45,14 @@ public final class ResultHandler {
             case 200..<300:
                 return
             default:
-                throw Error.init(statusCode: response.statusCode)
+                let errorResponseDTO = try response.map(ErrorResponseDTO.self, using: JSONDecoder())
+                throw Error.init(errorResponse: errorResponseDTO.toDomain)
             }
         case .failure(let error):
+            guard let response = error.response else { throw error }
+            if let errorResponseDTO = try? response.map(ErrorResponseDTO.self, using: JSONDecoder()) {
+                throw Error.init(errorResponse: errorResponseDTO.toDomain)
+            }
             throw error
         }
     }

--- a/Projects/Data/BaseData/Sources/TargetType/TimeCapsuleTargetType.swift
+++ b/Projects/Data/BaseData/Sources/TargetType/TimeCapsuleTargetType.swift
@@ -12,6 +12,7 @@ import Moya
 public enum TimeCapsuleTargetType {
     case fetchMyTimeCapsules
     case inviteToTimeCapsule(capsuleId: Int)
+    case joinRequest(code: String)
 }
 
 extension TimeCapsuleTargetType: BaseTargetType {
@@ -21,6 +22,8 @@ extension TimeCapsuleTargetType: BaseTargetType {
             return "/time-capsules/my"
         case .inviteToTimeCapsule(let capsuleId):
             return "/time-capsules/\(capsuleId)/invite"
+        case .joinRequest:
+            return "/time-capsules/join-request"
         }
     }
 
@@ -29,6 +32,8 @@ extension TimeCapsuleTargetType: BaseTargetType {
         case .fetchMyTimeCapsules:
             return .get
         case .inviteToTimeCapsule:
+            return .post
+        case .joinRequest:
             return .post
         }
     }
@@ -39,6 +44,8 @@ extension TimeCapsuleTargetType: BaseTargetType {
             return .requestPlain
         case .inviteToTimeCapsule:
             return .requestPlain
+        case .joinRequest(let code):
+            return .requestJSONEncodable(["code": code])
         }
     }
 
@@ -55,6 +62,8 @@ extension TimeCapsuleTargetType: BaseTargetType {
         case .fetchMyTimeCapsules:
             return true
         case .inviteToTimeCapsule:
+            return true
+        case .joinRequest:
             return true
         }
     }

--- a/Projects/Domain/AuthDomain/Sources/Error/AuthError.swift
+++ b/Projects/Domain/AuthDomain/Sources/Error/AuthError.swift
@@ -11,7 +11,7 @@ import BaseDomain
 public enum AuthError: DomainError {
     case defaultError
     
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Domain/BaseDomain/Sources/Entity/Error/ErrorResponseEntity.swift
+++ b/Projects/Domain/BaseDomain/Sources/Entity/Error/ErrorResponseEntity.swift
@@ -1,0 +1,23 @@
+//
+//  ErrorResponseEntity.swift
+//  BaseDomain
+//
+//  Created by 선민재 on 4/6/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+
+public struct ErrorResponseEntity: Equatable {
+    public let status: String
+    public let error: String
+    public let message: String
+    public let path: String
+
+    public init(status: String, error: String, message: String, path: String) {
+        self.status = status
+        self.error = error
+        self.message = message
+        self.path = path
+    }
+}

--- a/Projects/Domain/BaseDomain/Sources/Error/DomainError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/DomainError.swift
@@ -7,5 +7,5 @@
 //
 
 public protocol DomainError: Error, Equatable {
-    init(statusCode: Int)
+    init(errorResponse: ErrorResponseEntity)
 }

--- a/Projects/Domain/BaseDomain/Sources/Error/Refresh/RefreshError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/Refresh/RefreshError.swift
@@ -11,11 +11,14 @@ import Foundation
 public enum RefreshError: DomainError {
     case defaultError
     case tokenExpired
+    case notFoundUser
     
-    public init(statusCode: Int) {
-        switch statusCode {
-        case 401:
+    public init(errorResponse: ErrorResponseEntity) {
+        switch errorResponse.error {
+        case "EXPIRED_TOKEN":
             self = .tokenExpired
+        case "USER_NOT_FOUND":
+            self = .notFoundUser
         default:
             self = .defaultError
         }

--- a/Projects/Domain/BaseDomain/Sources/Error/TimeCapsule/TimeCapsuleError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/TimeCapsule/TimeCapsuleError.swift
@@ -6,10 +6,42 @@
 //  Copyright © 2026 MemorySeal. All rights reserved.
 //
 
-public enum TimeCapsuleError: DomainError {
-    case defaultError
+import Foundation
 
-    public init(statusCode: Int) {
-        self = .defaultError
+public enum TimeCapsuleError: DomainError, LocalizedError {
+    case defaultError
+    case invalidInviteCode
+    case timeCapsuleNotFound
+    case alreadyRequested
+    case alreadyContributor
+
+    public var errorDescription: String? {
+        switch self {
+        case .defaultError:
+            return "요청에 실패했습니다. 다시 시도해주세요."
+        case .invalidInviteCode:
+            return "유효하지 않거나 만료된 초대 코드입니다."
+        case .timeCapsuleNotFound:
+            return "타임캡슐을 찾을 수 없습니다."
+        case .alreadyRequested:
+            return "이미 공동작업자 요청을 보냈습니다."
+        case .alreadyContributor:
+            return "이미 공동작업자로 등록이 완료된 사용자입니다."
+        }
+    }
+
+    public init(errorResponse: ErrorResponseEntity) {
+        switch errorResponse.error {
+        case "INVALID_INVITE_CODE":
+            self = .invalidInviteCode
+        case "TIMECAPSULE_NOT_FOUND":
+            self = .timeCapsuleNotFound
+        case "ALREADY_REQUESTED":
+            self = .alreadyRequested
+        case "ALREADY_CONTRIBUTOR":
+            self = .alreadyContributor
+        default:
+            self = .defaultError
+        }
     }
 }

--- a/Projects/Domain/BaseDomain/Sources/Error/User/EditProfileError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/User/EditProfileError.swift
@@ -9,7 +9,7 @@
 public enum EditProfileError: DomainError {
     case defaultError
 
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Domain/BaseDomain/Sources/Error/User/UploadProfileImageError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/User/UploadProfileImageError.swift
@@ -9,7 +9,7 @@
 public enum UploadProfileImageError: DomainError {
     case defaultError
 
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Domain/BaseDomain/Sources/Error/User/UserInfoError.swift
+++ b/Projects/Domain/BaseDomain/Sources/Error/User/UserInfoError.swift
@@ -11,7 +11,7 @@ import BaseDomain
 public enum UserInfoError: DomainError {
     case defaultError
     
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Domain/BaseDomain/Sources/Repository/TimeCapsuleRepository.swift
+++ b/Projects/Domain/BaseDomain/Sources/Repository/TimeCapsuleRepository.swift
@@ -11,4 +11,5 @@ import Foundation
 public protocol TimeCapsuleRepository {
     func fetchMyTimeCapsules() async throws -> [TimeCapsuleEntity]
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
+    func joinRequest(code: String) async throws
 }

--- a/Projects/Domain/BaseDomain/Sources/UseCase/TimeCapsuleUseCase.swift
+++ b/Projects/Domain/BaseDomain/Sources/UseCase/TimeCapsuleUseCase.swift
@@ -11,6 +11,7 @@ import Foundation
 public protocol TimeCapsuleUseCase {
     func fetchMyTimeCapsules(role: TimeCapsuleRole) async throws -> [TimeCapsuleEntity]
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
+    func joinRequest(code: String) async throws
 }
 
 public final class DefaultTimeCapsuleUseCase: TimeCapsuleUseCase {
@@ -30,5 +31,9 @@ public final class DefaultTimeCapsuleUseCase: TimeCapsuleUseCase {
 
     public func inviteToTimeCapsule(capsuleId: Int) async throws -> String {
         return try await timeCapsuleRepository.inviteToTimeCapsule(capsuleId: capsuleId)
+    }
+
+    public func joinRequest(code: String) async throws {
+        try await timeCapsuleRepository.joinRequest(code: code)
     }
 }

--- a/Projects/Domain/CreateTicketDomain/Sources/Error/CreateTicketError.swift
+++ b/Projects/Domain/CreateTicketDomain/Sources/Error/CreateTicketError.swift
@@ -11,7 +11,7 @@ import BaseDomain
 public enum CreateTicketError: DomainError {
     case defaultError
 
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Domain/SignUpDomain/Sources/Error/SignUpError.swift
+++ b/Projects/Domain/SignUpDomain/Sources/Error/SignUpError.swift
@@ -11,7 +11,7 @@ import BaseDomain
 public enum SignUpError: DomainError {
     case defaultError
 
-    public init(statusCode: Int) {
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
         self = .defaultError
     }
 }

--- a/Projects/Feature/HomeFeature/Sources/DIContainer/HomeDIContainer.swift
+++ b/Projects/Feature/HomeFeature/Sources/DIContainer/HomeDIContainer.swift
@@ -55,7 +55,9 @@ public final class HomeDIContainer {
     }
 
     func makeEnterTicketViewModel() -> EnterTicketViewModel {
-        return EnterTicketViewModel()
+        return EnterTicketViewModel(
+            timeCapsuleUseCase: makeTimeCapsuleUseCase()
+        )
     }
 
     func makeEnterTicketViewController(viewModel: EnterTicketViewModel) -> EnterTicketViewController {

--- a/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
+++ b/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
@@ -134,7 +134,55 @@ extension EnterTicketViewController {
     }
     
     private func bindViewModel() {
-        
+        let didTapEnterButton: PublishRelay<String> = .init()
+
+        let input = EnterTicketViewModel.Input(
+            didTapEnterButton: didTapEnterButton
+        )
+        let output = viewModel.transform(input)
+
+        enterButton.rx.tap
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                guard let code = self.codeTextField.text, !code.isEmpty else { return }
+                didTapEnterButton.accept(code)
+            })
+            .disposed(by: disposeBag)
+
+        output.joinSuccess
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                self.dismiss(animated: true) {
+                    guard let window = UIApplication.shared.connectedScenes
+                        .compactMap({ $0 as? UIWindowScene })
+                        .first?.windows.first else { return }
+                    ToastView.show(on: window, message: "참여 코드 복사되었습니다.")
+                }
+            })
+            .disposed(by: disposeBag)
+
+        output.joinError
+            .withUnretained(self)
+            .subscribe(onNext: { (self, message) in
+                let dialog = DialogView.show(
+                    on: self.view,
+                    title: "합류 실패",
+                    message: message,
+                    cancelTitle: "닫기",
+                    confirmTitle: "확인"
+                )
+                dialog.cancelButtonDidTap
+                    .subscribe(onNext: { _ in
+                        dialog.dismiss()
+                    })
+                    .disposed(by: self.disposeBag)
+                dialog.confirmButtonDidTap
+                    .subscribe(onNext: { _ in
+                        dialog.dismiss()
+                    })
+                    .disposed(by: self.disposeBag)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindButton() {

--- a/Projects/Presentation/HomePresentation/Sources/EnterTicket/ViewModel/EnterTicketViewModel.swift
+++ b/Projects/Presentation/HomePresentation/Sources/EnterTicket/ViewModel/EnterTicketViewModel.swift
@@ -9,21 +9,51 @@
 import RxSwift
 import RxCocoa
 
+import BaseDomain
+
 public final class EnterTicketViewModel {
     private let disposeBag: DisposeBag = DisposeBag()
-    
+    private let timeCapsuleUseCase: TimeCapsuleUseCase
+
     struct Input {
-        
+        let didTapEnterButton: PublishRelay<String>
     }
-    
+
     struct Output {
-        
+        let joinSuccess: PublishRelay<Void>
+        let joinError: PublishRelay<String>
     }
-    
+
     func transform(_ input: Input) -> Output {
-        
-        return Output()
+        let joinSuccess: PublishRelay<Void> = .init()
+        let joinError: PublishRelay<String> = .init()
+
+        input.didTapEnterButton
+            .withUnretained(self)
+            .subscribe(onNext: { (self, code) in
+                Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        try await self.timeCapsuleUseCase.joinRequest(code: code)
+                        await MainActor.run {
+                            joinSuccess.accept(())
+                        }
+                    } catch let error {
+                        await MainActor.run {
+                            joinError.accept(error.localizedDescription)
+                        }
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
+        return Output(
+            joinSuccess: joinSuccess,
+            joinError: joinError
+        )
     }
-    
-    public init() { }
+
+    public init(timeCapsuleUseCase: TimeCapsuleUseCase) {
+        self.timeCapsuleUseCase = timeCapsuleUseCase
+    }
 }


### PR DESCRIPTION
 ## 변경 사항
  - EnterTicketViewController에서 참여코드 입력 후 `합류` 버튼 탭 시 `POST /time-capsules/join-request` API 호출
  - 성공(200) 시 화면 dismiss + Toast 메시지 표시
  - 실패 시 DialogView로 서버 에러 메시지 표시
  - `DomainError` 프로토콜 리팩토링: `init(errorResponse:)` 패턴으로 통일
  - `ResultHandler` failure 케이스에서도 `ErrorResponseDTO` 디코딩 처리
  - `ErrorResponseEntity`, `ErrorResponseDTO` 신규 생성
  - `TimeCapsuleError`에 서버 에러 케이스 추가 (`INVALID_INVITE_CODE`, `TIMECAPSULE_NOT_FOUND`, `ALREADY_REQUESTED`,
  `ALREADY_CONTRIBUTOR`)
  - `HomeDIContainer`에서 `EnterTicketViewModel`에 `TimeCapsuleUseCase` 주입