### PR TITLE
Feature: ToastView 피그마 디자인 적용 및 참여 완료 메시지 구현

### DIFF
--- a/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
+++ b/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
@@ -156,7 +156,7 @@ extension EnterTicketViewController {
                     guard let window = UIApplication.shared.connectedScenes
                         .compactMap({ $0 as? UIWindowScene })
                         .first?.windows.first else { return }
-                    ToastView.show(on: window, message: "참여 코드 복사되었습니다.")
+                    ToastView.show(on: window, message: "타임 캡슐 참여 요청이 완료되었어요.")
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
@@ -10,6 +10,13 @@ import UIKit
 import SnapKit
 
 public final class ToastView: UIView {
+    private let blurView: UIVisualEffectView = {
+        let blur = UIBlurEffect(style: .dark)
+        let view = UIVisualEffectView(effect: blur)
+        view.backgroundColor = UIColor(red: 11/255, green: 11/255, blue: 11/255, alpha: 0.48)
+        return view
+    }()
+
     private let iconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "checkmark.circle.fill")
@@ -21,7 +28,7 @@ public final class ToastView: UIView {
     private let messageLabel: UILabel = {
         let label = UILabel()
         label.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
-        label.textColor = DesignSystemAsset.ColorAssests.grey5.color
+        label.textColor = .white
         label.numberOfLines = 0
         return label
     }()
@@ -29,7 +36,7 @@ public final class ToastView: UIView {
     private let contentStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 8
+        stack.spacing = 6
         stack.alignment = .center
         return stack
     }()
@@ -37,26 +44,34 @@ public final class ToastView: UIView {
     private init(message: String) {
         super.init(frame: .zero)
 
-        self.backgroundColor = .white
+        self.backgroundColor = .clear
         self.layer.cornerRadius = 12
-        self.layer.shadowColor = UIColor.black.cgColor
-        self.layer.shadowOpacity = 0.1
-        self.layer.shadowOffset = CGSize(width: 0, height: 2)
+        self.layer.shadowColor = UIColor(red: 80/255, green: 80/255, blue: 80/255, alpha: 1.0).cgColor
+        self.layer.shadowOpacity = 0.16
+        self.layer.shadowOffset = CGSize(width: 0, height: 0)
         self.layer.shadowRadius = 8
+
+        blurView.layer.cornerRadius = 12
+        blurView.clipsToBounds = true
 
         messageLabel.text = message
 
         contentStackView.addArrangedSubview(iconImageView)
         contentStackView.addArrangedSubview(messageLabel)
 
+        addSubview(blurView)
         addSubview(contentStackView)
+
+        blurView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
 
         iconImageView.snp.makeConstraints {
             $0.size.equalTo(24)
         }
 
         contentStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20))
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
         }
     }
 


### PR DESCRIPTION
## 변경 사항

- **ToastView 디자인 업데이트**: 피그마 디자인에 맞게 다크 블러 배경(`UIVisualEffectView`), 흰색 텍스트, 패딩/간격 조정
- **EnterTicketViewController**: 타임캡슐 참여 성공 시 토스트 메시지를 `"타임 캡슐 참여 요청이 완료되었어요."`로 수정

## 테스트 방법

- [ ] 참여 코드 입력 후 합류 버튼 탭 → API 성공 시 다크 블러 토스트 노출 확인
- [ ] 토스트가 2초 후 자동으로 사라지는지 확인
- [ ] 토스트 애니메이션(위에서 슬라이드인/아웃) 정상 동작 확인