### PR TITLE
Refactor: ToastView 피그마 디자인 반영 및 노출 위치 옵션 추가

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
@@ -9,11 +9,23 @@
 import UIKit
 import SnapKit
 
+public enum ToastPosition {
+    case top
+    case bottom
+}
+
 public final class ToastView: UIView {
+    // MARK: - UI
     private let blurView: UIVisualEffectView = {
-        let blur = UIBlurEffect(style: .dark)
-        let view = UIVisualEffectView(effect: blur)
-        view.backgroundColor = UIColor(red: 11/255, green: 11/255, blue: 11/255, alpha: 0.48)
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+        view.layer.cornerRadius = 12
+        view.clipsToBounds = true
+        return view
+    }()
+
+    private let colorOverlay: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 0.043, green: 0.043, blue: 0.043, alpha: 0.48)
         return view
     }()
 
@@ -41,28 +53,52 @@ public final class ToastView: UIView {
         return stack
     }()
 
+    // MARK: - Init
     private init(message: String) {
         super.init(frame: .zero)
 
         self.backgroundColor = .clear
-        self.layer.cornerRadius = 12
-        self.layer.shadowColor = UIColor(red: 80/255, green: 80/255, blue: 80/255, alpha: 1.0).cgColor
+        self.clipsToBounds = false
+
+        // 그림자: Figma 디자인 값
+        self.layer.shadowColor = UIColor(red: 0.314, green: 0.314, blue: 0.314, alpha: 1.0).cgColor
         self.layer.shadowOpacity = 0.16
-        self.layer.shadowOffset = CGSize(width: 0, height: 0)
+        self.layer.shadowOffset = .zero
         self.layer.shadowRadius = 8
 
-        blurView.layer.cornerRadius = 12
-        blurView.clipsToBounds = true
+        // 블러 contentView 안에 오버레이 배치 (블러 위에 색상이 얹힘)
+        blurView.contentView.addSubview(colorOverlay)
 
         messageLabel.text = message
 
+        addSubviews()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: 12).cgPath
+    }
+
+    // MARK: - Layout
+    private func addSubviews() {
         contentStackView.addArrangedSubview(iconImageView)
         contentStackView.addArrangedSubview(messageLabel)
 
         addSubview(blurView)
         addSubview(contentStackView)
+    }
 
+    private func setLayout() {
         blurView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        colorOverlay.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
@@ -71,42 +107,59 @@ public final class ToastView: UIView {
         }
 
         contentStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16))
         }
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    public static func show(on view: UIView, message: String) {
+    // MARK: - Show
+    @discardableResult
+    public static func show(
+        on view: UIView,
+        message: String,
+        position: ToastPosition = .bottom
+    ) -> ToastView {
+        // 기존 토스트 제거
         view.subviews.compactMap { $0 as? ToastView }.forEach { $0.removeFromSuperview() }
+
         let toast = ToastView(message: message)
         view.addSubview(toast)
 
         toast.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(8)
             $0.leading.trailing.equalToSuperview().inset(20)
+
+            switch position {
+            case .top:
+                $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(8)
+            case .bottom:
+                $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(8)
+            }
         }
 
+        // 초기 상태
+        let slideOffset: CGFloat = position == .top ? -20 : 20
         toast.alpha = 0
-        toast.transform = CGAffineTransform(translationX: 0, y: -20)
+        toast.transform = CGAffineTransform(translationX: 0, y: slideOffset)
+
+        // 등장 애니메이션
         UIView.animate(withDuration: 0.25) {
             toast.alpha = 1
             toast.transform = .identity
         }
 
+        // 사라짐 애니메이션
         UIView.animate(
             withDuration: 0.25,
             delay: 2.0,
             options: [],
             animations: {
                 toast.alpha = 0
-                toast.transform = CGAffineTransform(translationX: 0, y: -20)
+                toast.transform = CGAffineTransform(translationX: 0, y: slideOffset)
             },
             completion: { _ in
                 toast.removeFromSuperview()
             }
         )
+
+        return toast
     }
 }


### PR DESCRIPTION
  변경 사항

  - ToastView 배경을 피그마 디자인대로 블러 + 다크 오버레이(rgba 0.043, 0.043, 0.043, 0.48) 조합으로 변경
  - 그림자를 피그마 값(rgba 0.314, 0.314, 0.314, 0.16, radius 8)으로 적용
  - ToastPosition enum 추가 (.top / .bottom) — 토스트 노출 위치 선택 가능
  - 기존 호출부 호환 유지 (position 파라미터 기본값 .bottom)