### PR TITLE
[Feature] Firebase Cloud Messaging 푸시 알림 연동

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -54,6 +54,9 @@ let project = Project(
                             ]
                         ]
                     ],
+                    "UIBackgroundModes": [
+                        "remote-notification"
+                    ],
                 ]
             ),
             sources: ["Sources/**"],

--- a/Projects/App/Resources/GoogleService-Info.plist
+++ b/Projects/App/Resources/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyA3vwFg21S2J5I0bHFHDDT46Biz2aKVeiA</string>
+	<key>GCM_SENDER_ID</key>
+	<string>1053803275178</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>io.tuist.MemorySeal</string>
+	<key>PROJECT_ID</key>
+	<string>memory-seal-7f5af</string>
+	<key>STORAGE_BUCKET</key>
+	<string>memory-seal-7f5af.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:1053803275178:ios:4f5679eb3c14e0292241d3</string>
+</dict>
+</plist>

--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -1,4 +1,6 @@
 import UIKit
+import FirebaseCore
+import FirebaseMessaging
 import GoogleSignIn
 
 @main
@@ -10,9 +12,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
+        FirebaseApp.configure()
+
+        UNUserNotificationCenter.current().delegate = self
+        Messaging.messaging().delegate = self
+
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { _, _ in }
+
+        application.registerForRemoteNotifications()
+
         return true
     }
-    
+
     func application(
         _ app: UIApplication,
         open url: URL,
@@ -21,7 +33,46 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       var handled: Bool
 
       handled = GIDSignIn.sharedInstance.handle(url)
-        
+
       return handled
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .badge, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        print("📩 알림 탭: \(userInfo)")
+        completionHandler()
+    }
+}
+
+// MARK: - MessagingDelegate
+
+extension AppDelegate: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let fcmToken = fcmToken else { return }
+        print("🔑 FCM Token: \(fcmToken)")
+        // TODO: 서버에 FCM 토큰 전송
     }
 }

--- a/Projects/App/Sources/Support/memorySeal.entitlements
+++ b/Projects/App/Sources/Support/memorySeal.entitlements
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<!--    <key>aps-environment</key>-->
-<!--    <string>development</string>-->
+    <key>aps-environment</key>
+    <string>development</string>
     <key>com.apple.developer.applesignin</key>
     <array>
         <string>Default</string>

--- a/Projects/ThridPartyLib/Project.swift
+++ b/Projects/ThridPartyLib/Project.swift
@@ -19,6 +19,7 @@ let project = Project.makeModule(
         .SPM.SnapKit,
         .SPM.Lottie,
         .SPM.Tabman,
-        .SPM.GoogleSignIn
+        .SPM.GoogleSignIn,
+        .SPM.FirebaseMessaging
     ]
 )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
@@ -28,6 +37,42 @@
       }
     },
     {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "fdc352fabaf5916e7faa1f96ad02b1957e93e5a5",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "a2d0f1f1666de591eb1a811f40b1706f5c63a2ed",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "45ce435e9406d3c674dd249a042b932bee006f60",
+        "version" : "11.15.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
       "identity" : "googlesignin-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleSignIn-iOS",
@@ -43,6 +88,15 @@
       "state" : {
         "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
         "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
       }
     },
     {
@@ -64,12 +118,30 @@
       }
     },
     {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
         "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
         "version" : "7.12.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -88,6 +160,15 @@
       "state" : {
         "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
         "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -133,6 +214,15 @@
       "state" : {
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.0.0"),
         .package(url: "https://github.com/airbnb/lottie-spm.git", from: "4.4.3"),
         .package(url: "https://github.com/uias/Tabman.git", from: "3.2.0"),
-        .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "9.0.0")
+        .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "9.0.0"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0")
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -20,4 +20,5 @@ public extension TargetDependency.SPM {
     static let Lottie = TargetDependency.external(name: "Lottie")
     static let Tabman = TargetDependency.external(name: "Tabman")
     static let GoogleSignIn = TargetDependency.external(name: "GoogleSignIn")
+    static let FirebaseMessaging = TargetDependency.external(name: "FirebaseMessaging")
 }


### PR DESCRIPTION
Summary

  - Firebase Cloud Messaging(FCM) 푸시 알림 기능 연동
  - Firebase SDK 의존성 추가 및 Tuist 설정 반영
  - AppDelegate에 FCM 초기화, 알림 권한 요청, 토큰 관리 로직 구현

  Changes

  - Tuist/Package.swift: firebase-ios-sdk SPM 패키지 추가
  - Dependency+SPM.swift: .SPM.FirebaseMessaging 헬퍼 추가
  - ThridPartyLib/Project.swift: FirebaseMessaging 의존성 추가
  - Project.swift: UIBackgroundModes: remote-notification 추가
  - memorySeal.entitlements: aps-environment 활성화
  - AppDelegate.swift: Firebase 초기화, UNUserNotificationCenter/Messaging delegate 구현
  - GoogleService-Info.plist: Firebase 설정 파일 추가

  TODO

  - FCM 토큰 서버 전송 API 연동
  - 알림 탭 시 특정 화면 이동 (딥링크) 처리
  - Apple Developer Console Push Notifications capability 활성화 확인
  - Firebase Console에 APNs Key (.p8) 업로드