### PR TITLE
[Feature] 티켓 생성 화면 wavy 디자인 적용

### DIFF
--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
@@ -60,6 +60,7 @@ public final class CreateTicketViewController: UIViewController {
             lineWidth: 3
         )
         view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
         view.isUserInteractionEnabled = false
         return view
     }()
@@ -91,6 +92,7 @@ public final class CreateTicketViewController: UIViewController {
             lineWidth: 3
         )
         view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
         view.isUserInteractionEnabled = false
         return view
     }()
@@ -119,6 +121,7 @@ public final class CreateTicketViewController: UIViewController {
             lineWidth: 3
         )
         view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
         view.isUserInteractionEnabled = false
         return view
     }()
@@ -151,17 +154,7 @@ public final class CreateTicketViewController: UIViewController {
             lineWidth: 3
         )
         view.waveCornerRadius = 12
-        view.isUserInteractionEnabled = false
-        return view
-    }()
-
-    private let createButtonWavyBackground: WavyStrokeView = {
-        let view = WavyStrokeView(
-            fillColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
-            strokeColor: UIColor(hex: "#29A047") ?? DesignSystemAsset.ColorAssests.primaryDark.color,
-            lineWidth: 3
-        )
-        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
         view.isUserInteractionEnabled = false
         return view
     }()
@@ -171,8 +164,20 @@ public final class CreateTicketViewController: UIViewController {
         button.setTitle("생성", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-        button.backgroundColor = .clear
+        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
+        button.layer.cornerRadius = 12
         return button
+    }()
+
+    private let createButtonWavyStrokeView: WavyStrokeView = {
+        let view = WavyStrokeView(
+            strokeColor: UIColor(hex: "#29A047") ?? DesignSystemAsset.ColorAssests.primaryDark.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
+        view.isUserInteractionEnabled = false
+        return view
     }()
 
     public init(with viewModel: CreateTicketViewModel) {
@@ -378,8 +383,8 @@ extension CreateTicketViewController {
         scrollView.addSubview(calendarView)
         scrollView.addSubview(calendarWavyStrokeView)
 
-        scrollView.addSubview(createButtonWavyBackground)
         scrollView.addSubview(createButton)
+        scrollView.addSubview(createButtonWavyStrokeView)
     }
 
     private func setLayout() {
@@ -476,7 +481,7 @@ extension CreateTicketViewController {
             $0.height.equalTo(48)
         }
 
-        createButtonWavyBackground.snp.makeConstraints {
+        createButtonWavyStrokeView.snp.makeConstraints {
             $0.edges.equalTo(createButton)
         }
     }

--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
@@ -48,12 +48,20 @@ public final class CreateTicketViewController: UIViewController {
     private let ticketImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = DesignSystemAsset.ImageAssets.ticketNoneImage.image
-        imageView.layer.borderColor = DesignSystemAsset.ColorAssests.grey2.color.cgColor
-        imageView.layer.borderWidth = 1
         imageView.layer.cornerRadius = 12
         imageView.layer.masksToBounds = true
         imageView.isUserInteractionEnabled = true
         return imageView
+    }()
+
+    private let ticketImageWavyStrokeView: WavyStrokeView = {
+        let view = WavyStrokeView(
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.isUserInteractionEnabled = false
+        return view
     }()
 
     private let ticketTitleLabel: UILabel = {
@@ -73,10 +81,18 @@ public final class CreateTicketViewController: UIViewController {
             color: DesignSystemAsset.ColorAssests.grey3.color,
             font: DesignSystemFontFamily.Pretendard.regular.font(size: 16)
         )
-        textField.layer.borderColor = DesignSystemAsset.ColorAssests.grey2.color.cgColor
-        textField.layer.borderWidth = 1
         textField.layer.cornerRadius = 12
         return textField
+    }()
+
+    private let ticketTitleWavyStrokeView: WavyStrokeView = {
+        let view = WavyStrokeView(
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.isUserInteractionEnabled = false
+        return view
     }()
 
     private let descriptionTitleLabel: UILabel = {
@@ -91,12 +107,20 @@ public final class CreateTicketViewController: UIViewController {
         let textView = UITextView()
         textView.textColor = DesignSystemAsset.ColorAssests.grey5.color
         textView.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
-        textView.layer.borderColor = DesignSystemAsset.ColorAssests.grey2.color.cgColor
-        textView.layer.borderWidth = 1
         textView.layer.cornerRadius = 12
         textView.textContainerInset = .init(top: 14.0, left: 12.0, bottom: 14.0, right: 12.0)
         textView.isScrollEnabled = false
         return textView
+    }()
+
+    private let descriptionWavyStrokeView: WavyStrokeView = {
+        let view = WavyStrokeView(
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.isUserInteractionEnabled = false
+        return view
     }()
 
     private let descriptionPlaceholderLabel: UILabel = {
@@ -117,9 +141,28 @@ public final class CreateTicketViewController: UIViewController {
 
     private let calendarView: MemorySealCalendarView = {
         let view = MemorySealCalendarView()
-        view.layer.borderColor = DesignSystemAsset.ColorAssests.grey2.color.cgColor
-        view.layer.borderWidth = 1
         view.layer.cornerRadius = 12
+        return view
+    }()
+
+    private let calendarWavyStrokeView: WavyStrokeView = {
+        let view = WavyStrokeView(
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let createButtonWavyBackground: WavyStrokeView = {
+        let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
+            strokeColor: UIColor(hex: "#29A047") ?? DesignSystemAsset.ColorAssests.primaryDark.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.isUserInteractionEnabled = false
         return view
     }()
 
@@ -128,8 +171,7 @@ public final class CreateTicketViewController: UIViewController {
         button.setTitle("생성", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
-        button.layer.cornerRadius = 12
+        button.backgroundColor = .clear
         return button
     }()
 
@@ -321,17 +363,22 @@ extension CreateTicketViewController {
 
         scrollView.addSubview(photoTitleLabel)
         scrollView.addSubview(ticketImageView)
+        scrollView.addSubview(ticketImageWavyStrokeView)
 
         scrollView.addSubview(ticketTitleLabel)
         scrollView.addSubview(ticketTitleTextField)
+        scrollView.addSubview(ticketTitleWavyStrokeView)
 
         scrollView.addSubview(descriptionTitleLabel)
         scrollView.addSubview(descriptionTextView)
         scrollView.addSubview(descriptionPlaceholderLabel)
+        scrollView.addSubview(descriptionWavyStrokeView)
 
         scrollView.addSubview(calendarTitleLabel)
         scrollView.addSubview(calendarView)
+        scrollView.addSubview(calendarWavyStrokeView)
 
+        scrollView.addSubview(createButtonWavyBackground)
         scrollView.addSubview(createButton)
     }
 
@@ -362,6 +409,10 @@ extension CreateTicketViewController {
             $0.width.height.equalTo(120)
         }
 
+        ticketImageWavyStrokeView.snp.makeConstraints {
+            $0.edges.equalTo(ticketImageView)
+        }
+
         ticketTitleLabel.snp.makeConstraints {
             $0.top.equalTo(ticketImageView.snp.bottom).offset(16)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
@@ -375,6 +426,10 @@ extension CreateTicketViewController {
             $0.height.equalTo(48)
         }
 
+        ticketTitleWavyStrokeView.snp.makeConstraints {
+            $0.edges.equalTo(ticketTitleTextField)
+        }
+
         descriptionTitleLabel.snp.makeConstraints {
             $0.top.equalTo(ticketTitleTextField.snp.bottom).offset(16)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
@@ -386,6 +441,10 @@ extension CreateTicketViewController {
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(20)
             $0.height.greaterThanOrEqualTo(48)
+        }
+
+        descriptionWavyStrokeView.snp.makeConstraints {
+            $0.edges.equalTo(descriptionTextView)
         }
 
         descriptionPlaceholderLabel.snp.makeConstraints {
@@ -405,12 +464,20 @@ extension CreateTicketViewController {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(20)
         }
 
+        calendarWavyStrokeView.snp.makeConstraints {
+            $0.edges.equalTo(calendarView)
+        }
+
         createButton.snp.makeConstraints {
             $0.top.equalTo(calendarView.snp.bottom).offset(24)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(20)
             $0.bottom.equalTo(scrollView.snp.bottom).inset(24)
             $0.height.equalTo(48)
+        }
+
+        createButtonWavyBackground.snp.makeConstraints {
+            $0.edges.equalTo(createButton)
         }
     }
 }

--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
@@ -159,18 +159,9 @@ public final class CreateTicketViewController: UIViewController {
         return view
     }()
 
-    private let createButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("생성", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
-        button.layer.cornerRadius = 12
-        return button
-    }()
-
-    private let createButtonWavyStrokeView: WavyStrokeView = {
+    private let createButtonWavyBackground: WavyStrokeView = {
         let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
             strokeColor: UIColor(hex: "#29A047") ?? DesignSystemAsset.ColorAssests.primaryDark.color,
             lineWidth: 3
         )
@@ -178,6 +169,15 @@ public final class CreateTicketViewController: UIViewController {
         view.strokeAlignment = .outside
         view.isUserInteractionEnabled = false
         return view
+    }()
+
+    private let createButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("생성", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        button.backgroundColor = .clear
+        return button
     }()
 
     public init(with viewModel: CreateTicketViewModel) {
@@ -383,8 +383,8 @@ extension CreateTicketViewController {
         scrollView.addSubview(calendarView)
         scrollView.addSubview(calendarWavyStrokeView)
 
+        scrollView.addSubview(createButtonWavyBackground)
         scrollView.addSubview(createButton)
-        scrollView.addSubview(createButtonWavyStrokeView)
     }
 
     private func setLayout() {
@@ -481,7 +481,7 @@ extension CreateTicketViewController {
             $0.height.equalTo(48)
         }
 
-        createButtonWavyStrokeView.snp.makeConstraints {
+        createButtonWavyBackground.snp.makeConstraints {
             $0.edges.equalTo(createButton)
         }
     }

--- a/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
@@ -18,6 +18,14 @@ public enum WavyStrokeStyle {
     case filledStroked(fill: UIColor, stroke: UIColor, lineWidth: CGFloat)
 }
 
+/// `.stroked` 모드에서 wavy 외곽선이 뷰 bounds 기준 어느 쪽으로 형성될지 결정.
+public enum WavyStrokeAlignment {
+    /// 외곽선이 bounds 안쪽에 형성된다.
+    case inside
+    /// 외곽선이 bounds 바깥쪽으로 확장된다. 안쪽 콘텐츠 영역을 그대로 두고 데코레이션만 바깥에 그릴 때.
+    case outside
+}
+
 public final class WavyStrokeView: UIView {
 
     // MARK: - Properties
@@ -43,6 +51,11 @@ public final class WavyStrokeView: UIView {
 
     /// 흔들림 패턴 결정 시드. 같은 값이면 레이아웃이 바뀌어도 동일 패턴이 그려진다.
     public var noiseSeed: UInt64 = 0xC0FFEE_BABE {
+        didSet { updateAppearance() }
+    }
+
+    /// `.stroked` 모드에서 stroke가 그려지는 방향. 기본은 `.inside`.
+    public var strokeAlignment: WavyStrokeAlignment = .inside {
         didSet { updateAppearance() }
     }
 
@@ -154,10 +167,17 @@ public final class WavyStrokeView: UIView {
                 return 0
             }
         }()
-        let totalInset = amp + strokeBuffer
-        let inset = bounds.insetBy(dx: totalInset, dy: totalInset)
+        let baseInset = amp + strokeBuffer
+        // outside 모드일 때 path baseline을 bounds 바깥으로 옮긴다 (.stroked에서만 적용).
+        let signedInset: CGFloat = {
+            if case .stroked = style, strokeAlignment == .outside {
+                return -baseInset
+            }
+            return baseInset
+        }()
+        let inset = bounds.insetBy(dx: signedInset, dy: signedInset)
         let radius = max(0, min(
-            waveCornerRadius - totalInset,
+            waveCornerRadius - signedInset,
             min(inset.width, inset.height) / 2
         ))
 

--- a/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
@@ -18,11 +18,11 @@ public enum WavyStrokeStyle {
     case filledStroked(fill: UIColor, stroke: UIColor, lineWidth: CGFloat)
 }
 
-/// `.stroked` 모드에서 wavy 외곽선이 뷰 bounds 기준 어느 쪽으로 형성될지 결정.
+/// `.stroked` / `.filledStroked` 모드에서 wavy path가 뷰 bounds 기준 어느 쪽으로 형성될지 결정.
 public enum WavyStrokeAlignment {
-    /// 외곽선이 bounds 안쪽에 형성된다.
+    /// path가 bounds 안쪽에 형성된다 (기본).
     case inside
-    /// 외곽선이 bounds 바깥쪽으로 확장된다. 안쪽 콘텐츠 영역을 그대로 두고 데코레이션만 바깥에 그릴 때.
+    /// path가 bounds 바깥쪽으로 확장된다. 안쪽 영역을 그대로 두고 wave 데코레이션만 바깥에 그릴 때.
     case outside
 }
 
@@ -168,12 +168,14 @@ public final class WavyStrokeView: UIView {
             }
         }()
         let baseInset = amp + strokeBuffer
-        // outside 모드일 때 path baseline을 bounds 바깥으로 옮긴다 (.stroked에서만 적용).
+        // outside 모드일 때 path baseline을 bounds 바깥으로 옮긴다 (.stroked, .filledStroked).
         let signedInset: CGFloat = {
-            if case .stroked = style, strokeAlignment == .outside {
+            switch (style, strokeAlignment) {
+            case (.stroked, .outside), (.filledStroked, .outside):
                 return -baseInset
+            default:
+                return baseInset
             }
-            return baseInset
         }()
         let inset = bounds.insetBy(dx: signedInset, dy: signedInset)
         let radius = max(0, min(


### PR DESCRIPTION
## 변경 사항

  ### CreateTicketViewController (티켓 생성 화면)
  - 사진 업로드 박스 / 제목 / 설명 / 달력 입력 영역의 직선 border 제거
    - 각 입력 위에 `WavyStrokeView(.stroked)` overlay 추가 (`grey1` `#E6E6E6` 3pt, `waveCornerRadius` 12)
    - `strokeAlignment = .outside`로 wave가 입력 콘텐츠 영역 안쪽을 침범하지 않고 바깥으로만 형성
  - 생성 버튼: `WavyStrokeView(.filledStroked)` + `.outside` 배경으로 교체
    - fill(`primaryNormal`) + stroke(`#29A047` 3pt)이 같은 wavy path를 따라가서 버튼 일체형으로 노출
    - 안쪽 콘텐츠 영역(`bounds`)은 그대로 유지, wave는 바깥으로만 형성

  ### WavyStrokeView
  - `WavyStrokeAlignment` enum 추가 (`.inside` / `.outside`)
  - `strokeAlignment` 속성 노출 (`.stroked`, `.filledStroked`에 적용)
  - `.outside` 모드일 때 path baseline을 `-(amp + lineWidth/2)` 만큼 bounds 바깥으로 옮기고 corner arc
  radius도 자동 보정해 parent rounded rect와 동심 유지