### PR TITLE
Refactor: 공통 토스트 디자인 리뉴얼

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
@@ -23,9 +23,21 @@ public final class ToastView: UIView {
         return view
     }()
 
+    private var wavyStrokeLayer: WavyStrokeLayer?
+
     private let colorOverlay: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor(red: 0.043, green: 0.043, blue: 0.043, alpha: 0.48)
+        return view
+    }()
+
+    private let secondaryShadowView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.layer.shadowColor = UIColor(red: 80/255, green: 80/255, blue: 80/255, alpha: 1.0).cgColor
+        view.layer.shadowOpacity = 0.16
+        view.layer.shadowOffset = .zero
+        view.layer.shadowRadius = 8
         return view
     }()
 
@@ -60,19 +72,27 @@ public final class ToastView: UIView {
         self.backgroundColor = .clear
         self.clipsToBounds = false
 
-        // 그림자: Figma 디자인 값
-        self.layer.shadowColor = UIColor(red: 0.314, green: 0.314, blue: 0.314, alpha: 1.0).cgColor
-        self.layer.shadowOpacity = 0.16
-        self.layer.shadowOffset = .zero
+        self.layer.shadowColor = UIColor.black.cgColor
+        self.layer.shadowOpacity = 0.25
+        self.layer.shadowOffset = CGSize(width: 0, height: 4)
         self.layer.shadowRadius = 8
 
-        // 블러 contentView 안에 오버레이 배치 (블러 위에 색상이 얹힘)
         blurView.contentView.addSubview(colorOverlay)
 
         messageLabel.text = message
 
         addSubviews()
         setLayout()
+        setupWavyStroke()
+    }
+
+    private func setupWavyStroke() {
+        wavyStrokeLayer = self.addWavyStrokeLayer(
+            strokeColor: DesignSystemAsset.ColorAssests.grey4.color,
+            lineWidth: 3,
+            cornerRadius: 12,
+            alignment: .outside
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -81,7 +101,14 @@ public final class ToastView: UIView {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        self.layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: 12).cgPath
+        let path = UIBezierPath(roundedRect: bounds, cornerRadius: 12).cgPath
+        self.layer.shadowPath = path
+        secondaryShadowView.layer.shadowPath = path
+
+        if let wavyStrokeLayer, wavyStrokeLayer.frame != bounds {
+            wavyStrokeLayer.frame = bounds
+            wavyStrokeLayer.setNeedsPathRefresh()
+        }
     }
 
     // MARK: - Layout
@@ -89,11 +116,16 @@ public final class ToastView: UIView {
         contentStackView.addArrangedSubview(iconImageView)
         contentStackView.addArrangedSubview(messageLabel)
 
+        addSubview(secondaryShadowView)
         addSubview(blurView)
         addSubview(contentStackView)
     }
 
     private func setLayout() {
+        secondaryShadowView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
         blurView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -107,7 +139,14 @@ public final class ToastView: UIView {
         }
 
         contentStackView.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16))
+            $0.edges.equalToSuperview().inset(
+                UIEdgeInsets(
+                    top: 12,
+                    left: 16,
+                    bottom: 12,
+                    right: 16
+                )
+            )
         }
     }
 


### PR DESCRIPTION
## 변경 사항

- 공통 `ToastView` 의 솔리드 border 제거 후 `WavyStrokeLayer` (grey4 / 3pt / cornerRadius 12 / `.outside`) 로 교체하여 프로젝트 wavy 비주얼 일관성 확보
- 메인 그림자 갱신: `0px 4px 8px rgba(0,0,0,0.25)`
- 보조 glow 그림자 (`0px 0px 8px rgba(80,80,80,0.16)`) 를 별도 `secondaryShadowView` 로 분리하여 UIView 단일 layer 의 dual-shadow 한계 우회
- `layoutSubviews` 에서 wavy stroke frame/path 동기화 로직 추가

## 테스트 방법

- [ ] `make generate` 후 빌드 성공 확인
- [ ] `AddMember` 화면에서 참여 코드 복사 / 에러 메시지 노출 시 토스트가 새 디자인 (wavy stroke + 듀얼 그림자) 으로 표시되는지 확인
- [ ] `EnterTicket` 화면에서 타임 캡슐 참여 요청 완료 토스트가 새 디자인으로 표시되는지 확인
- [ ] 토스트 등장/사라짐 슬라이드 + fade 애니메이션이 기존과 동일하게 동작하는지 확인
- [ ] 토스트 height 가 48pt (12 + 24 + 12) 로 Figma 노드 사이즈 (335×48) 와 일치하는지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)