### PR TITLE
Refactor: 참여코드 입력 팝업 UI 정렬 + 코드 주석 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,4 @@ Chore: {빌드, 설정, 의존성 등 기능과 무관한 작업}
 - `withUnretained(self)` 로 메모리 누수 방지
 - ViewController UI 초기화는 `setInitialValues()` → `addSubviews()` → `setLayout()` → `bindViewModel()` 순서
 - ViewModel delegate는 `weak var delegate` 로 선언
+- **주석 작성 금지**: `// MARK: -` 섹션 구분 외에는 어떠한 주석도 추가하지 않는다 (설명 / 의도 / TODO / 워크어라운드 메모 모두 포함). 새 코드 작성 시는 물론 기존 코드 수정 시에도 주석을 새로 만들지 말 것. 변경 의도는 커밋 메시지 / PR 본문으로만 기록한다.

--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
@@ -15,8 +15,6 @@ import RxCocoa
 import CalendarDomain
 import DesignSystem
 
-/// `layoutSubviews` 콜백으로 외부에서 bounds 변화를 추적할 수 있는 UITextView.
-/// wavy stroke 레이어처럼 호스트 layer 의 사이즈 변경을 즉시 반영해야 하는 경우 사용한다.
 private final class LayoutTrackingTextView: UITextView {
     var onLayoutSubviews: (() -> Void)?
 
@@ -197,8 +195,6 @@ public final class CreateTicketViewController: UIViewController {
         if layer.frame != bounds {
             layer.frame = bounds
         }
-        // CALayer 의 frame setter 가 Swift override 를 우회하는 케이스(예: Core Animation
-        // transaction 내부 갱신) 에 대비해 path 재생성을 명시적으로 한 번 더 트리거한다.
         layer.setNeedsPathRefresh()
     }
 
@@ -329,8 +325,6 @@ extension CreateTicketViewController {
             })
             .disposed(by: disposeBag)
 
-        // 줄바꿈 직후 / 텍스트 삭제 후 textView 의 intrinsicContentSize 가 자동으로 재계산되지 않아
-        // 높이 반영이 늦어지고, 늘어났던 wavy stroke 가 다시 줄어들지 않는 문제 방지.
         descriptionTextView.rx.didChange
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
@@ -471,16 +465,11 @@ extension CreateTicketViewController {
             alignment: .outside
         )
 
-        // calendarView 는 collectionView contentSize 변화로 비동기적으로 크기가 결정되므로
-        // 자체 layoutSubviews 콜백을 통해 wavy layer 를 갱신한다.
         calendarView.onLayoutSubviews = { [weak self] in
             guard let self else { return }
             self.syncWavyStrokeLayer(self.calendarWavyLayer, to: self.calendarView.bounds)
         }
 
-        // descriptionTextView 는 텍스트 입력/삭제로 intrinsicContentSize 가 즉시 갱신되지 않거나
-        // viewDidLayoutSubviews 가 늦게 도달하는 경우가 있어 텍스트 뷰 자체 layoutSubviews 시점에
-        // wavy layer 를 동기화한다.
         descriptionTextView.onLayoutSubviews = { [weak self] in
             guard let self else { return }
             self.syncWavyStrokeLayer(self.descriptionWavyLayer, to: self.descriptionTextView.bounds)

--- a/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
+++ b/Projects/Presentation/HomePresentation/Sources/EnterTicket/Controller/EnterTicketViewController.swift
@@ -18,7 +18,7 @@ public final class EnterTicketViewController: UIViewController {
     
     private let popUpBackgroundView: UIView = {
         let view = UIView()
-        view.backgroundColor = DesignSystemAsset.ColorAssests.backgroundNormal.color
+        view.backgroundColor = .white
         view.layer.cornerRadius = 24
         view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         return view
@@ -40,14 +40,27 @@ public final class EnterTicketViewController: UIViewController {
             color: DesignSystemAsset.ColorAssests.grey3.color,
             font: DesignSystemFontFamily.Pretendard.regular.font(size: 16)
         )
+        textField.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
+        textField.textColor = DesignSystemAsset.ColorAssests.grey5.color
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
         textField.leftViewMode = .always
-        textField.layer.cornerRadius = 12
-        textField.layer.borderColor = DesignSystemAsset.ColorAssests.grey2.color.cgColor
-        textField.layer.borderWidth = 1
         return textField
     }()
-    
+
+    private var codeTextFieldWavyLayer: WavyStrokeLayer?
+
+    private let cancelButtonWavyBg: WavyStrokeView = {
+        let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.grey1.color,
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
     private let cancelButton: UIButton = {
         let button = UIButton()
         button.setTitle("취소", for: .normal)
@@ -55,12 +68,23 @@ public final class EnterTicketViewController: UIViewController {
             DesignSystemAsset.ColorAssests.grey4.color,
             for: .normal
         )
-        button.backgroundColor = DesignSystemAsset.ColorAssests.grey1.color
+        button.backgroundColor = .clear
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-        button.layer.cornerRadius = 12
         return button
     }()
-    
+
+    private let enterButtonWavyBg: WavyStrokeView = {
+        let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.primaryLight.color,
+            strokeColor: DesignSystemAsset.ColorAssests.primaryLight.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
     private let enterButton: UIButton = {
         let button = UIButton()
         button.setTitle("합류", for: .normal)
@@ -72,16 +96,8 @@ public final class EnterTicketViewController: UIViewController {
             .white,
             for: .normal
         )
-        button.setBackgroundColor(
-            color: DesignSystemAsset.ColorAssests.primaryLight.color,
-            forState: .disabled
-        )
-        button.setBackgroundColor(
-            color: DesignSystemAsset.ColorAssests.primaryNormal.color,
-            forState: .normal
-        )
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
-        button.layer.cornerRadius = 12
+        button.backgroundColor = .clear
         button.isEnabled = false
         return button
     }()
@@ -97,16 +113,47 @@ public final class EnterTicketViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.codeTextField.becomeFirstResponder()
         self.setBackgroundView()
         self.addSubViews()
         self.setLayout()
+        self.setupWavyStrokeLayer()
+        self.applyEnterButtonState(enabled: false)
         self.observeKeyboardHeight()
-        
+
         self.bindViewModel()
         self.bindButton()
         self.bindTextField()
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        guard let codeTextFieldWavyLayer else { return }
+        if codeTextFieldWavyLayer.frame != codeTextField.bounds {
+            codeTextFieldWavyLayer.frame = codeTextField.bounds
+        }
+        codeTextFieldWavyLayer.setNeedsPathRefresh()
+    }
+
+    private func setupWavyStrokeLayer() {
+        codeTextFieldWavyLayer = codeTextField.addWavyStrokeLayer(
+            strokeColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
+            lineWidth: 3,
+            cornerRadius: 12,
+            alignment: .outside
+        )
+    }
+
+    private func applyEnterButtonState(enabled: Bool) {
+        let color = enabled
+            ? DesignSystemAsset.ColorAssests.primaryNormal.color
+            : DesignSystemAsset.ColorAssests.primaryLight.color
+        enterButtonWavyBg.style = .filledStroked(
+            fill: color,
+            stroke: color,
+            lineWidth: 3
+        )
     }
     
     public override func viewDidDisappear(_ animated: Bool) {
@@ -198,7 +245,9 @@ extension EnterTicketViewController {
         codeTextField.rx.text.changed
             .withUnretained(self)
             .subscribe(onNext: { (self, content) in
-                self.enterButton.isEnabled = !(content?.isEmpty ?? false)
+                let isEnabled = !(content?.isEmpty ?? false)
+                self.enterButton.isEnabled = isEnabled
+                self.applyEnterButtonState(enabled: isEnabled)
             })
             .disposed(by: disposeBag)
     }
@@ -225,27 +274,29 @@ extension EnterTicketViewController {
         view.addSubview(popUpBackgroundView)
         popUpBackgroundView.addSubview(titleLabel)
         popUpBackgroundView.addSubview(codeTextField)
+        popUpBackgroundView.addSubview(cancelButtonWavyBg)
         popUpBackgroundView.addSubview(cancelButton)
+        popUpBackgroundView.addSubview(enterButtonWavyBg)
         popUpBackgroundView.addSubview(enterButton)
     }
-    
+
     private func setLayout() {
         popUpBackgroundView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
-        
+
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(24)
+            $0.top.equalToSuperview().offset(32)
             $0.leading.trailing.equalToSuperview()
         }
-        
+
         codeTextField.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(48)
         }
-        
+
         cancelButton.snp.makeConstraints {
             $0.top.equalTo(codeTextField.snp.bottom).offset(24)
             $0.leading.equalToSuperview().offset(20)
@@ -253,13 +304,21 @@ extension EnterTicketViewController {
             $0.height.equalTo(48)
             $0.width.equalTo(80)
         }
-        
+
+        cancelButtonWavyBg.snp.makeConstraints {
+            $0.edges.equalTo(cancelButton)
+        }
+
         enterButton.snp.makeConstraints {
             $0.top.equalTo(codeTextField.snp.bottom).offset(24)
             $0.leading.equalTo(cancelButton.snp.trailing).offset(8)
             $0.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(24)
             $0.height.equalTo(48)
+        }
+
+        enterButtonWavyBg.snp.makeConstraints {
+            $0.edges.equalTo(enterButton)
         }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Toast/ToastView.swift
@@ -157,7 +157,6 @@ public final class ToastView: UIView {
         message: String,
         position: ToastPosition = .bottom
     ) -> ToastView {
-        // 기존 토스트 제거
         view.subviews.compactMap { $0 as? ToastView }.forEach { $0.removeFromSuperview() }
 
         let toast = ToastView(message: message)
@@ -174,18 +173,15 @@ public final class ToastView: UIView {
             }
         }
 
-        // 초기 상태
         let slideOffset: CGFloat = position == .top ? -20 : 20
         toast.alpha = 0
         toast.transform = CGAffineTransform(translationX: 0, y: slideOffset)
 
-        // 등장 애니메이션
         UIView.animate(withDuration: 0.25) {
             toast.alpha = 1
             toast.transform = .identity
         }
 
-        // 사라짐 애니메이션
         UIView.animate(
             withDuration: 0.25,
             delay: 2.0,

--- a/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeLayer.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeLayer.swift
@@ -8,9 +8,6 @@
 
 import UIKit
 
-/// 손그림 느낌의 wavy 외곽선을 호스트 뷰의 layer 위에 직접 그리는 CAShapeLayer.
-/// `WavyStrokeView` 와 달리 별도의 sibling UIView 가 아닌 layer 단위로 동작하므로
-/// 호스트 bounds 와 동기화 슬립 없이 항상 같은 크기로 따라 움직인다.
 public final class WavyStrokeLayer: CAShapeLayer {
 
     // MARK: - Configurable
@@ -63,7 +60,6 @@ public final class WavyStrokeLayer: CAShapeLayer {
 
     // MARK: - Public API
 
-    /// stroke 색만 갈아끼우는 헬퍼. lineWidth/path 는 유지된다.
     public func setWavyStrokeColor(_ color: UIColor) {
         strokeColor = color.cgColor
     }
@@ -92,7 +88,6 @@ public final class WavyStrokeLayer: CAShapeLayer {
         }
     }
 
-    /// 외부에서 강제로 path 재생성을 요청한다 (host bounds 가 늦게 결정되는 경우 보조용).
     public func setNeedsPathRefresh() {
         regeneratePath()
     }
@@ -111,9 +106,6 @@ public final class WavyStrokeLayer: CAShapeLayer {
         let amp = waveAmplitude
         let strokeBuffer = lineWidth / 2
         let baseInset = amp + strokeBuffer
-        // outside 모드는 path baseline 을 host bounds 위에 정확히 둔다 (signedInset = 0).
-        // 이렇게 하면 perturb ±amp 로 wave 가 bounds 를 가로질러 진동하고,
-        // stroke 픽셀이 항상 host 가장자리를 덮어 antialiasing 갭이 발생하지 않는다.
         let signedInset: CGFloat = (alignment == .outside) ? 0 : baseInset
         let inset = bounds.insetBy(dx: signedInset, dy: signedInset)
         let radius = max(0, min(
@@ -297,9 +289,6 @@ public final class WavyStrokeLayer: CAShapeLayer {
 // MARK: - UIView attach helper
 
 public extension UIView {
-    /// 호스트 뷰의 layer 위에 wavy stroke 를 그리는 layer 를 추가한다.
-    /// 호스트가 `masksToBounds = true` 인 경우 outside 영역이 잘리므로,
-    /// 그런 호스트는 컨테이너 뷰로 감싸 컨테이너 layer 에 붙이는 것을 권장한다.
     @discardableResult
     func addWavyStrokeLayer(
         strokeColor: UIColor,

--- a/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIViews/WavyStrokeView.swift
@@ -8,21 +8,14 @@
 
 import UIKit
 
-/// 손그림 느낌의 불규칙한 경계를 표현하는 뷰의 렌더링 스타일.
 public enum WavyStrokeStyle {
-    /// wavy 모양으로 뷰 전체를 채운다. 자식 뷰는 wavy 영역으로 클리핑된다.
     case filled(color: UIColor)
-    /// wavy 외곽선만 그린다. 다른 뷰 위에 덧씌우는 데코레이션 용도.
     case stroked(color: UIColor, lineWidth: CGFloat)
-    /// 같은 wavy path를 fill + stroke로 그린다. 자식 뷰가 stroke 외곽선 안쪽에만 보이는 SVG 티켓 스타일.
     case filledStroked(fill: UIColor, stroke: UIColor, lineWidth: CGFloat)
 }
 
-/// `.stroked` / `.filledStroked` 모드에서 wavy path가 뷰 bounds 기준 어느 쪽으로 형성될지 결정.
 public enum WavyStrokeAlignment {
-    /// path가 bounds 안쪽에 형성된다 (기본).
     case inside
-    /// path가 bounds 바깥쪽으로 확장된다. 안쪽 영역을 그대로 두고 wave 데코레이션만 바깥에 그릴 때.
     case outside
 }
 
@@ -34,32 +27,26 @@ public final class WavyStrokeView: UIView {
         didSet { applyStyle() }
     }
 
-    /// 경계가 흔들리는 진폭(픽셀).
     public var waveAmplitude: CGFloat = 2.0 {
         didSet { updateAppearance() }
     }
 
-    /// 경계 위 샘플 점 사이의 간격(픽셀).
     public var waveSpacing: CGFloat = 6.0 {
         didSet { updateAppearance() }
     }
 
-    /// 모서리 라운드 반경.
     public var waveCornerRadius: CGFloat = 16.0 {
         didSet { updateAppearance() }
     }
 
-    /// 흔들림 패턴 결정 시드. 같은 값이면 레이아웃이 바뀌어도 동일 패턴이 그려진다.
     public var noiseSeed: UInt64 = 0xC0FFEE_BABE {
         didSet { updateAppearance() }
     }
 
-    /// `.stroked` 모드에서 stroke가 그려지는 방향. 기본은 `.inside`.
     public var strokeAlignment: WavyStrokeAlignment = .inside {
         didSet { updateAppearance() }
     }
 
-    /// 현재 스타일을 유지하면서 stroke 색만 갈아끼운다 (`.stroked`, `.filledStroked` 한정).
     public func setStrokeColor(_ color: UIColor) {
         switch style {
         case .stroked(_, let lineWidth):
@@ -149,7 +136,6 @@ public final class WavyStrokeView: UIView {
 
     public override func didAddSubview(_ subview: UIView) {
         super.didAddSubview(subview)
-        // 새 자식의 layer 위에 stroke가 다시 올라오도록 sublayer 순서를 끝으로 옮긴다.
         if !strokeLayer.isHidden {
             layer.addSublayer(strokeLayer)
         }
@@ -170,7 +156,6 @@ public final class WavyStrokeView: UIView {
 
     private func makeWavyPath() -> UIBezierPath {
         let amp = waveAmplitude
-        // stroke 외곽선이 waveCornerRadius 기준 rounded rect 경계와 일치하도록 inset 보정.
         let strokeBuffer: CGFloat = {
             switch style {
             case .stroked(_, let lineWidth), .filledStroked(_, _, let lineWidth):
@@ -180,8 +165,6 @@ public final class WavyStrokeView: UIView {
             }
         }()
         let baseInset = amp + strokeBuffer
-        // outside 모드는 path baseline 을 host bounds 위에 정확히 두어 wave 가 bounds 를 가로질러 진동하게 한다.
-        // 이렇게 하면 stroke 픽셀이 host 가장자리를 항상 덮어 antialiasing 갭이 보이지 않는다.
         let signedInset: CGFloat = {
             switch (style, strokeAlignment) {
             case (.stroked, .outside), (.filledStroked, .outside):
@@ -224,7 +207,6 @@ public final class WavyStrokeView: UIView {
     ) -> [PerimeterSample] {
         var result: [PerimeterSample] = []
 
-        // Top edge (→)
         appendLine(
             from: CGPoint(x: rect.minX + r, y: rect.minY),
             to: CGPoint(x: rect.maxX - r, y: rect.minY),
@@ -232,7 +214,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Top-right corner
         appendArc(
             center: CGPoint(x: rect.maxX - r, y: rect.minY + r),
             radius: r,
@@ -241,7 +222,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Right edge (↓)
         appendLine(
             from: CGPoint(x: rect.maxX, y: rect.minY + r),
             to: CGPoint(x: rect.maxX, y: rect.maxY - r),
@@ -249,7 +229,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Bottom-right corner
         appendArc(
             center: CGPoint(x: rect.maxX - r, y: rect.maxY - r),
             radius: r,
@@ -258,7 +237,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Bottom edge (←)
         appendLine(
             from: CGPoint(x: rect.maxX - r, y: rect.maxY),
             to: CGPoint(x: rect.minX + r, y: rect.maxY),
@@ -266,7 +244,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Bottom-left corner
         appendArc(
             center: CGPoint(x: rect.minX + r, y: rect.maxY - r),
             radius: r,
@@ -275,7 +252,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Left edge (↑)
         appendLine(
             from: CGPoint(x: rect.minX, y: rect.maxY - r),
             to: CGPoint(x: rect.minX, y: rect.minY + r),
@@ -283,7 +259,6 @@ public final class WavyStrokeView: UIView {
             spacing: spacing,
             into: &result
         )
-        // Top-left corner
         appendArc(
             center: CGPoint(x: rect.minX + r, y: rect.minY + r),
             radius: r,


### PR DESCRIPTION
## 변경 사항

### 참여코드 입력 팝업 UI Figma 정렬
- popup 배경 `backgroundNormal (#F5F5F5) → white`, 상단 padding `24 → 32` (Figma `pt-32`)
- 코드 입력 TextField: 솔리드 grey2 border 제거 후 `WavyStrokeLayer` (primaryNormal, 3pt, cornerRadius 12, `.outside`) attach. `viewDidLayoutSubviews` 에서 textField bounds 와 동기화. font/textColor 명시 (Pretendard Regular 16, grey5)
- 취소 버튼: 솔리드 → 별도 `cancelButtonWavyBg` `WavyStrokeView` (`.filledStroked`, fill/stroke 모두 grey1, 3pt) 백그라운드 + 버튼은 clear. 텍스트 grey4 Pretendard Bold 16 유지
- 합류 버튼: 솔리드 → `enterButtonWavyBg` (`.filledStroked`) 백그라운드 + `applyEnterButtonState(enabled:)` 토글 — disabled 시 `primaryLight (#cff2d8)` + 텍스트 `grey3 (#919191)`, enabled 시 `primaryNormal (#34C759)` + 텍스트 white. `bindTextField` 에서 입력 변경마다 호출

### 코드 주석 정리 + 주석 작성 금지 규칙 추가
- `CLAUDE.md` 코드 규칙 섹션에 "`// MARK: -` 외 어떠한 주석도 새로 작성하지 않는다" 규칙 명시
- 기존 코드의 explanatory / docstring 주석 일괄 제거 (`// MARK: -` + Xcode 자동 헤더만 보존):
  - `WavyStrokeView` / `WavyStrokeLayer` 의 public API 도큐 코멘트 + 내부 보조 주석
  - `ToastView.show` 의 단계별 주석
  - `CreateTicketViewController` 의 `LayoutTrackingTextView` 도큐 / `syncWavyStrokeLayer` 보조 주석 / TextView 콜백 보조 주석

## 테스트 방법

- [ ] `make generate` 후 빌드 성공 확인
- [ ] 참여코드 팝업 진입 시 배경이 white, popup 상단 여백 32pt 로 표시되는지 확인
- [ ] 코드 입력 TextField 에 초록 wavy stroke 가 외곽에 표시되는지 확인
- [ ] 취소 버튼이 grey1 wavy filled 모양으로 표시되는지 확인
- [ ] 합류 버튼이 처음엔 light-green wavy + grey 텍스트 (disabled), 코드 입력 시 normal-green wavy + white 텍스트 (enabled) 로 전환되는지 확인
- [ ] 합류 → 성공 토스트, 합류 → 실패 다이얼로그가 정상 동작하는지 확인
- [ ] 키보드 height 변동에 따라 popup 위치가 정상 추적되는지 확인
- [ ] 변경된 파일들에 explanatory 주석이 남아 있지 않은지 확인 (Xcode 헤더 / `// MARK: -` 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)