### PR TITLE
Refactor: 공통 DialogView 디자인 Figma 반영

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
@@ -15,7 +15,7 @@ public final class DialogView: UIView {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
-        label.textColor = DesignSystemAsset.ColorAssests.grey5.color
+        label.textColor = .black
         label.numberOfLines = 0
         return label
     }()
@@ -23,7 +23,7 @@ public final class DialogView: UIView {
     private let messageLabel: UILabel = {
         let label = UILabel()
         label.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
-        label.textColor = DesignSystemAsset.ColorAssests.grey5.color
+        label.textColor = DesignSystemAsset.ColorAssests.grey4.color
         label.numberOfLines = 0
         return label
     }()
@@ -37,26 +37,52 @@ public final class DialogView: UIView {
 
     private let cancelButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.backgroundColor = DesignSystemAsset.ColorAssests.grey1.color
+        button.backgroundColor = .clear
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
         button.setTitleColor(DesignSystemAsset.ColorAssests.grey4.color, for: .normal)
-        button.layer.cornerRadius = 12
         return button
     }()
 
+    private let cancelButtonWavyBackground: WavyStrokeView = {
+        let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.grey1.color,
+            strokeColor: DesignSystemAsset.ColorAssests.grey1.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let cancelButtonContainer = UIView()
+
     private let confirmButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
+        button.backgroundColor = .clear
         button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
         button.setTitleColor(.white, for: .normal)
-        button.layer.cornerRadius = 12
         return button
     }()
+
+    private let confirmButtonWavyBackground: WavyStrokeView = {
+        let view = WavyStrokeView(
+            fillColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
+            strokeColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
+            lineWidth: 3
+        )
+        view.waveCornerRadius = 12
+        view.strokeAlignment = .outside
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let confirmButtonContainer = UIView()
 
     private let buttonStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 8
+        stack.spacing = 12
         stack.distribution = .fillEqually
         return stack
     }()
@@ -160,8 +186,13 @@ extension DialogView {
         textStackView.addArrangedSubview(titleLabel)
         textStackView.addArrangedSubview(messageLabel)
 
-        buttonStackView.addArrangedSubview(cancelButton)
-        buttonStackView.addArrangedSubview(confirmButton)
+        cancelButtonContainer.addSubview(cancelButtonWavyBackground)
+        cancelButtonContainer.addSubview(cancelButton)
+        confirmButtonContainer.addSubview(confirmButtonWavyBackground)
+        confirmButtonContainer.addSubview(confirmButton)
+
+        buttonStackView.addArrangedSubview(cancelButtonContainer)
+        buttonStackView.addArrangedSubview(confirmButtonContainer)
 
         addSubview(textStackView)
         addSubview(buttonStackView)
@@ -178,6 +209,19 @@ extension DialogView {
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalToSuperview().inset(24)
             $0.height.equalTo(48)
+        }
+
+        cancelButtonWavyBackground.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        cancelButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        confirmButtonWavyBackground.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        confirmButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 }


### PR DESCRIPTION
## 변경 사항

- 취소 / 확인 버튼을 솔리드 배경 → `WavyStrokeView` (`.filledStroked`, `.outside`, lineWidth 3pt, `waveCornerRadius 12`) 일체형으로 교체. fill 색과 동일 색 stroke 적용 (취소=grey1, 확인=primaryNormal)
- 각 버튼을 wrapper 컨테이너로 감싸 wavy 배경 + 버튼을 같은 영역에 겹쳐 배치
- 버튼 사이 간격 `8 → 12`
- 타이틀 텍스트 컬러 `grey5 → black`
- 메시지 텍스트 컬러 `grey5 → grey4 (#454545)`

## 테스트 방법

- [ ] `make generate` 후 빌드 성공 확인
- [ ] DialogView 노출 화면에서 타이틀이 black, 메시지가 grey4 로 표시되는지 확인
- [ ] 취소 / 확인 버튼이 wavy filled 형태 (각각 grey1 / primaryNormal) 로 표시되는지 확인
- [ ] 두 버튼 사이 간격이 12pt 로 보이는지 확인
- [ ] 두 버튼 탭 동작이 기존과 동일하게 cancelButtonDidTap / confirmButtonDidTap 으로 전파되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)