### PR TITLE
Refactor: 멤버 추가 화면 UI Figma 반영

### DIFF
--- a/Projects/Presentation/MemoryPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
@@ -21,7 +21,7 @@ public final class AddMemberViewController: UIViewController {
     private let viewModel: AddMemberViewModel
     private let navigationView: MemorySealNavigationView = {
         let view = MemorySealNavigationView()
-        view.setTitle("맴버 추가")
+        view.setTitle("멤버 추가")
         return view
     }()
 
@@ -190,7 +190,7 @@ extension AddMemberViewController {
         }
 
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(navigationView.snp.bottom).offset(8)
+            $0.top.equalTo(navigationView.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview()
         }

--- a/Projects/Presentation/MemoryPresentation/Sources/AddMember/View/AddMemberCollectionViewCell.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/AddMember/View/AddMemberCollectionViewCell.swift
@@ -12,39 +12,23 @@ import SnapKit
 import DesignSystem
 
 final class AddMemberCollectionViewCell: UICollectionViewCell {
-    
+
     private let userImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = DesignSystemAsset.ImageAssets.userDefaultProfileImage.image
-        imageView.layer.cornerRadius = 17
-        imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = false
         return imageView
     }()
-    
+
     private let userNickNameLabel: UILabel = {
         let label = UILabel()
         label.text = "나는야 유저 유저!"
-        label.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
+        label.font = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
         label.textColor = DesignSystemAsset.ColorAssests.grey5.color
         return label
     }()
-    
-    private let refusalButton: UIButton = {
-        let button = UIButton()
-        button.setTitle(
-            "거절",
-            for: .normal
-        )
-        button.setTitleColor(
-            DesignSystemAsset.ColorAssests.grey4.color,
-            for: .normal
-        )
-        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
-        button.backgroundColor = DesignSystemAsset.ColorAssests.grey1.color
-        button.layer.cornerRadius = 8
-        return button
-    }()
-    
+
     private let acceptButton: UIButton = {
         let button = UIButton()
         button.setTitle(
@@ -60,15 +44,15 @@ final class AddMemberCollectionViewCell: UICollectionViewCell {
         button.layer.cornerRadius = 8
         return button
     }()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .white
-        
+
         self.addSubviews()
         self.setLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -78,35 +62,27 @@ extension AddMemberCollectionViewCell {
     private func addSubviews() {
         addSubview(userImageView)
         addSubview(acceptButton)
-        addSubview(refusalButton)
         addSubview(userNickNameLabel)
     }
-    
+
     private func setLayout() {
         userImageView.snp.makeConstraints {
-            $0.top.leading.bottom.equalToSuperview()
-            $0.width.height.equalTo(48)
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(40)
         }
-        
+
         acceptButton.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview().inset(8)
+            $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.height.equalTo(32)
             $0.width.equalTo(49)
         }
-        
-        refusalButton.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview().inset(8)
-            $0.trailing.equalTo(acceptButton.snp.leading).offset(-8)
-            $0.height.equalTo(32)
-            $0.width.equalTo(49)
-        }
-        
+
         userNickNameLabel.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.leading.equalTo(userImageView.snp.trailing).offset(8)
-            $0.trailing.equalTo(refusalButton.snp.leading).offset(-8)
-            $0.width.greaterThanOrEqualTo(142)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(userImageView.snp.trailing).offset(12)
+            $0.trailing.lessThanOrEqualTo(acceptButton.snp.leading).offset(-16)
         }
     }
 }


### PR DESCRIPTION
## 변경 사항

### AddMemberCollectionViewCell
- 거절 버튼 제거 후 수락 버튼 단일 구성으로 정리 (Figma 동일)
- 닉네임 폰트 `Pretendard.regular 16 → medium 16`, 이미지 ↔ 닉네임 간격 `8 → 12`, 닉네임 ↔ 수락 버튼 간격 `8 → 16`
- 셀 내부 모든 요소 `centerY` 정렬 (Figma `h-full items-center` 매칭)
- 프로필 이미지: `cornerRadius` / `clipsToBounds` / `borderWidth` 모두 제거
  - `UserDefaultProfileImage` 자산이 wobbly 손그림 테두리를 이미 갖고 있어 perfect circle 클리핑이 자산의 wobbly 외곽선을 잘라내는 부작용 발생 → 자산 그대로 노출
  - `contentMode = .scaleAspectFit`

### AddMemberViewController
- 네비 타이틀 오타 수정 (`맴버 추가` → `멤버 추가`)
- 본문 상단 padding `8 → 12` (Figma `py-12`)

## 테스트 방법

- [ ] `make generate` 후 빌드 성공 확인
- [ ] 멤버 추가 화면 진입 시 네비 타이틀이 "멤버 추가" 로 표시되는지 확인
- [ ] 각 셀의 placeholder 프로필 이미지의 wobbly 손그림 테두리가 잘리지 않고 온전히 보이는지 확인
- [ ] 닉네임이 medium 16pt 로 표시되고 이미지/수락 버튼과 적절한 간격으로 정렬되는지 확인
- [ ] 수락 버튼이 light-green wavy bg + primaryDark 텍스트로 표시되는지 확인
- [ ] 네비 + 버튼 → 참여 링크 공유 / 참여 코드 복사 드롭다운 / 토스트 노출이 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)