### PR TITLE
Feature: 나의 추억 메시지/사진 작성·조회·삭제 기능 구현

### DIFF
--- a/Projects/Data/MemoryData/Project.swift
+++ b/Projects/Data/MemoryData/Project.swift
@@ -1,19 +1,11 @@
-//
-//  Project.swift
-//  Manifests
-//
-//  Created by 선민재 on 7/28/25.
-//
-
 import ProjectDescription
 import ProjectDescriptionHelpers
 
 let project = Project.makeModule(
-    name: "MemoryFeature",
+    name: "MemoryData",
     product: .staticFramework,
     dependencies: [
-        .Presentation.MemoryPresentation,
         .Data.BaseData,
-        .Data.MemoryData
+        .Domain.MemoryDomain
     ]
 )

--- a/Projects/Data/MemoryData/Resources/placeHolder.swift
+++ b/Projects/Data/MemoryData/Resources/placeHolder.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
+++ b/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
@@ -56,4 +56,13 @@ public final class DefaultCapsuleContentRepository: CapsuleContentRepository {
 
         return responseDTO.toDomain
     }
+
+    public func deleteContent(contentId: Int) async throws {
+        let result = await provider.request(.deleteContent(contentId: contentId))
+
+        try ResultHandler.handleResult(
+            result: result,
+            errorType: CapsuleContentError.self
+        )
+    }
 }

--- a/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
+++ b/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
@@ -31,4 +31,29 @@ public final class DefaultCapsuleContentRepository: CapsuleContentRepository {
     public func fetchCurrentUserId() -> Int? {
         return userDefaultStorage.get(forKey: .userId) as? Int
     }
+
+    public func createTextContent(capsuleId: Int, content: String) async throws -> CapsuleContent {
+        let requestDTO = CreateContentRequestDTO(content: content)
+        let result = await provider.request(.createTextContent(capsuleId: capsuleId, request: requestDTO))
+
+        let responseDTO = try ResultHandler.handleResult(
+            result: result,
+            responseType: CreateCapsuleContentResponseDTO.self,
+            errorType: CapsuleContentError.self
+        )
+
+        return responseDTO.toDomain
+    }
+
+    public func createPhotoContent(capsuleId: Int, images: [Data]) async throws -> CapsuleContent {
+        let result = await provider.request(.createPhotoContent(capsuleId: capsuleId, images: images))
+
+        let responseDTO = try ResultHandler.handleResult(
+            result: result,
+            responseType: CreateCapsuleContentResponseDTO.self,
+            errorType: CapsuleContentError.self
+        )
+
+        return responseDTO.toDomain
+    }
 }

--- a/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
+++ b/Projects/Data/MemoryData/Sources/Repository/DefaultCapsuleContentRepository.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+import BaseData
+import MemoryDomain
+
+public final class DefaultCapsuleContentRepository: CapsuleContentRepository {
+
+    private let provider: DefaultProvider<CapsuleContentTargetType>
+    private let userDefaultStorage: UserDefaultStorage
+
+    public init(
+        provider: DefaultProvider<CapsuleContentTargetType>,
+        userDefaultStorage: UserDefaultStorage
+    ) {
+        self.provider = provider
+        self.userDefaultStorage = userDefaultStorage
+    }
+
+    public func fetchCapsuleContents(capsuleId: Int) async throws -> [CapsuleContentGroupEntity] {
+        let result = await provider.request(.fetchCapsuleContents(capsuleId: capsuleId))
+
+        let responseDTOs = try ResultHandler.handleResult(
+            result: result,
+            responseType: [CapsuleContentGroupResponseDTO].self,
+            errorType: CapsuleContentError.self
+        )
+
+        return responseDTOs.map { $0.toDomain }
+    }
+
+    public func fetchCurrentUserId() -> Int? {
+        return userDefaultStorage.get(forKey: .userId) as? Int
+    }
+}

--- a/Projects/Data/MemoryData/Sources/RequestDTO/CreateContentRequestDTO.swift
+++ b/Projects/Data/MemoryData/Sources/RequestDTO/CreateContentRequestDTO.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct CreateContentRequestDTO: Encodable {
+    let content: String
+
+    public init(content: String) {
+        self.content = content
+    }
+}

--- a/Projects/Data/MemoryData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
+++ b/Projects/Data/MemoryData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
@@ -31,3 +31,17 @@ struct CapsuleContentResponseDTO: Decodable {
         }
     }
 }
+
+struct CreateCapsuleContentResponseDTO: Decodable {
+    let contentId: Int
+    let content: String?
+    let attachedFileUrls: [String]?
+
+    var toDomain: CapsuleContent {
+        if let content = content, !content.isEmpty {
+            return .text(id: contentId, content: content)
+        } else {
+            return .photo(id: contentId, imageUrls: attachedFileUrls ?? [])
+        }
+    }
+}

--- a/Projects/Data/MemoryData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
+++ b/Projects/Data/MemoryData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+import MemoryDomain
+
+struct CapsuleContentGroupResponseDTO: Decodable {
+    let userId: Int
+    let nickname: String
+    let profileImageUrl: String
+    let capsuleContents: [CapsuleContentResponseDTO]
+
+    var toDomain: CapsuleContentGroupEntity {
+        return .init(
+            userId: userId,
+            nickname: nickname,
+            profileImageUrl: profileImageUrl,
+            contents: capsuleContents.map { $0.toDomain }
+        )
+    }
+}
+
+struct CapsuleContentResponseDTO: Decodable {
+    let contentId: Int
+    let content: String?
+    let attachedFileUrls: [String]?
+
+    var toDomain: CapsuleContent {
+        if let content = content, !content.isEmpty {
+            return .text(id: contentId, content: content)
+        } else {
+            return .photo(id: contentId, imageUrls: attachedFileUrls ?? [])
+        }
+    }
+}

--- a/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
+++ b/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
@@ -7,6 +7,7 @@ public enum CapsuleContentTargetType {
     case fetchCapsuleContents(capsuleId: Int)
     case createTextContent(capsuleId: Int, request: CreateContentRequestDTO)
     case createPhotoContent(capsuleId: Int, images: [Data])
+    case deleteContent(contentId: Int)
 }
 
 extension CapsuleContentTargetType: BaseTargetType {
@@ -17,6 +18,8 @@ extension CapsuleContentTargetType: BaseTargetType {
         case .createTextContent(let capsuleId, _),
              .createPhotoContent(let capsuleId, _):
             return "/api/time-capsule-content/\(capsuleId)"
+        case .deleteContent(let contentId):
+            return "/api/time-capsule-content/\(contentId)"
         }
     }
 
@@ -26,6 +29,8 @@ extension CapsuleContentTargetType: BaseTargetType {
             return .get
         case .createTextContent, .createPhotoContent:
             return .post
+        case .deleteContent:
+            return .delete
         }
     }
 
@@ -53,6 +58,9 @@ extension CapsuleContentTargetType: BaseTargetType {
                 )
             }
             return .uploadMultipart(parts)
+
+        case .deleteContent:
+            return .requestPlain
         }
     }
 
@@ -62,7 +70,7 @@ extension CapsuleContentTargetType: BaseTargetType {
 
     public var isNeededAccessToken: Bool {
         switch self {
-        case .fetchCapsuleContents, .createTextContent, .createPhotoContent:
+        case .fetchCapsuleContents, .createTextContent, .createPhotoContent, .deleteContent:
             return true
         }
     }

--- a/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
+++ b/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Moya
+
+import BaseData
+
+public enum CapsuleContentTargetType {
+    case fetchCapsuleContents(capsuleId: Int)
+}
+
+extension CapsuleContentTargetType: BaseTargetType {
+    public var path: String {
+        switch self {
+        case .fetchCapsuleContents(let capsuleId):
+            return "/api/time-capsule-content/\(capsuleId)/contents"
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .fetchCapsuleContents:
+            return .get
+        }
+    }
+
+    public var task: Moya.Task {
+        switch self {
+        case .fetchCapsuleContents:
+            return .requestPlain
+        }
+    }
+
+    public var headers: [String: String]? {
+        return nil
+    }
+
+    public var isNeededAccessToken: Bool {
+        switch self {
+        case .fetchCapsuleContents:
+            return true
+        }
+    }
+}

--- a/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
+++ b/Projects/Data/MemoryData/Sources/TargetType/CapsuleContentTargetType.swift
@@ -5,6 +5,8 @@ import BaseData
 
 public enum CapsuleContentTargetType {
     case fetchCapsuleContents(capsuleId: Int)
+    case createTextContent(capsuleId: Int, request: CreateContentRequestDTO)
+    case createPhotoContent(capsuleId: Int, images: [Data])
 }
 
 extension CapsuleContentTargetType: BaseTargetType {
@@ -12,6 +14,9 @@ extension CapsuleContentTargetType: BaseTargetType {
         switch self {
         case .fetchCapsuleContents(let capsuleId):
             return "/api/time-capsule-content/\(capsuleId)/contents"
+        case .createTextContent(let capsuleId, _),
+             .createPhotoContent(let capsuleId, _):
+            return "/api/time-capsule-content/\(capsuleId)"
         }
     }
 
@@ -19,6 +24,8 @@ extension CapsuleContentTargetType: BaseTargetType {
         switch self {
         case .fetchCapsuleContents:
             return .get
+        case .createTextContent, .createPhotoContent:
+            return .post
         }
     }
 
@@ -26,6 +33,26 @@ extension CapsuleContentTargetType: BaseTargetType {
         switch self {
         case .fetchCapsuleContents:
             return .requestPlain
+
+        case .createTextContent(_, let request):
+            let jsonData = (try? JSONEncoder().encode(request)) ?? Data()
+            let requestPart = MultipartFormData(
+                provider: .data(jsonData),
+                name: "request",
+                mimeType: "application/json"
+            )
+            return .uploadMultipart([requestPart])
+
+        case .createPhotoContent(_, let images):
+            let parts = images.enumerated().map { index, data in
+                MultipartFormData(
+                    provider: .data(data),
+                    name: "files",
+                    fileName: "photo_\(index).jpg",
+                    mimeType: "image/jpeg"
+                )
+            }
+            return .uploadMultipart(parts)
         }
     }
 
@@ -35,7 +62,7 @@ extension CapsuleContentTargetType: BaseTargetType {
 
     public var isNeededAccessToken: Bool {
         switch self {
-        case .fetchCapsuleContents:
+        case .fetchCapsuleContents, .createTextContent, .createPhotoContent:
             return true
         }
     }

--- a/Projects/Data/MemoryData/Tests/placeHolder.swift
+++ b/Projects/Data/MemoryData/Tests/placeHolder.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Projects/Domain/MemoryDomain/Project.swift
+++ b/Projects/Domain/MemoryDomain/Project.swift
@@ -1,0 +1,10 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: "MemoryDomain",
+    product: .staticFramework,
+    dependencies: [
+        .Domain.BaseDomain
+    ]
+)

--- a/Projects/Domain/MemoryDomain/Resources/placeHolder.swift
+++ b/Projects/Domain/MemoryDomain/Resources/placeHolder.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Projects/Domain/MemoryDomain/Sources/Entity/CapsuleContent.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Entity/CapsuleContent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum CapsuleContent {
+    case text(id: Int, content: String)
+    case photo(id: Int, imageUrls: [String])
+
+    public var id: Int {
+        switch self {
+        case .text(let id, _): return id
+        case .photo(let id, _): return id
+        }
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/Entity/CapsuleContentGroupEntity.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Entity/CapsuleContentGroupEntity.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct CapsuleContentGroupEntity {
+    public let userId: Int
+    public let nickname: String
+    public let profileImageUrl: String
+    public let contents: [CapsuleContent]
+
+    public init(
+        userId: Int,
+        nickname: String,
+        profileImageUrl: String,
+        contents: [CapsuleContent]
+    ) {
+        self.userId = userId
+        self.nickname = nickname
+        self.profileImageUrl = profileImageUrl
+        self.contents = contents
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/Error/CapsuleContentError.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Error/CapsuleContentError.swift
@@ -1,0 +1,9 @@
+import BaseDomain
+
+public enum CapsuleContentError: DomainError {
+    case defaultError
+
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
+        self = .defaultError
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
@@ -3,4 +3,6 @@ import Foundation
 public protocol CapsuleContentRepository {
     func fetchCapsuleContents(capsuleId: Int) async throws -> [CapsuleContentGroupEntity]
     func fetchCurrentUserId() -> Int?
+    func createTextContent(capsuleId: Int, content: String) async throws -> CapsuleContent
+    func createPhotoContent(capsuleId: Int, images: [Data]) async throws -> CapsuleContent
 }

--- a/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol CapsuleContentRepository {
+    func fetchCapsuleContents(capsuleId: Int) async throws -> [CapsuleContentGroupEntity]
+    func fetchCurrentUserId() -> Int?
+}

--- a/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Repository/CapsuleContentRepository.swift
@@ -5,4 +5,5 @@ public protocol CapsuleContentRepository {
     func fetchCurrentUserId() -> Int?
     func createTextContent(capsuleId: Int, content: String) async throws -> CapsuleContent
     func createPhotoContent(capsuleId: Int, images: [Data]) async throws -> CapsuleContent
+    func deleteContent(contentId: Int) async throws
 }

--- a/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
+++ b/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public protocol CapsuleContentUseCase {
+    func execute(capsuleId: Int) async throws -> [CapsuleContent]
+}
+
+public final class DefaultCapsuleContentUseCase: CapsuleContentUseCase {
+
+    private let capsuleContentRepository: CapsuleContentRepository
+
+    public init(capsuleContentRepository: CapsuleContentRepository) {
+        self.capsuleContentRepository = capsuleContentRepository
+    }
+
+    public func execute(capsuleId: Int) async throws -> [CapsuleContent] {
+        let groups = try await capsuleContentRepository.fetchCapsuleContents(capsuleId: capsuleId)
+
+        guard let currentUserId = capsuleContentRepository.fetchCurrentUserId() else {
+            throw CapsuleContentError.defaultError
+        }
+
+        return groups.first { $0.userId == currentUserId }?.contents ?? []
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
+++ b/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public protocol CapsuleContentUseCase {
     func execute(capsuleId: Int) async throws -> [CapsuleContent]
+    func createText(capsuleId: Int, content: String) async throws -> CapsuleContent
+    func createPhotos(capsuleId: Int, images: [Data]) async throws -> CapsuleContent
 }
 
 public final class DefaultCapsuleContentUseCase: CapsuleContentUseCase {
@@ -20,5 +22,13 @@ public final class DefaultCapsuleContentUseCase: CapsuleContentUseCase {
         }
 
         return groups.first { $0.userId == currentUserId }?.contents ?? []
+    }
+
+    public func createText(capsuleId: Int, content: String) async throws -> CapsuleContent {
+        return try await capsuleContentRepository.createTextContent(capsuleId: capsuleId, content: content)
+    }
+
+    public func createPhotos(capsuleId: Int, images: [Data]) async throws -> CapsuleContent {
+        return try await capsuleContentRepository.createPhotoContent(capsuleId: capsuleId, images: images)
     }
 }

--- a/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
+++ b/Projects/Domain/MemoryDomain/Sources/UseCase/CapsuleContentUseCase.swift
@@ -4,6 +4,7 @@ public protocol CapsuleContentUseCase {
     func execute(capsuleId: Int) async throws -> [CapsuleContent]
     func createText(capsuleId: Int, content: String) async throws -> CapsuleContent
     func createPhotos(capsuleId: Int, images: [Data]) async throws -> CapsuleContent
+    func delete(contentId: Int) async throws
 }
 
 public final class DefaultCapsuleContentUseCase: CapsuleContentUseCase {
@@ -30,5 +31,9 @@ public final class DefaultCapsuleContentUseCase: CapsuleContentUseCase {
 
     public func createPhotos(capsuleId: Int, images: [Data]) async throws -> CapsuleContent {
         return try await capsuleContentRepository.createPhotoContent(capsuleId: capsuleId, images: images)
+    }
+
+    public func delete(contentId: Int) async throws {
+        try await capsuleContentRepository.deleteContent(contentId: contentId)
     }
 }

--- a/Projects/Domain/MemoryDomain/Tests/placeHolder.swift
+++ b/Projects/Domain/MemoryDomain/Tests/placeHolder.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Projects/Feature/MemoryFeature/Sources/Coordinator/MemoryCoordinator.swift
+++ b/Projects/Feature/MemoryFeature/Sources/Coordinator/MemoryCoordinator.swift
@@ -55,7 +55,7 @@ public final class MemoryCoordinator {
     // MARK: - MyMemoryMessages
 
     public func moveToMyMemoryMessages() {
-        let vc = memoryDIContainer.makeMyMemoryMessagesViewController()
+        let vc = memoryDIContainer.makeMyMemoryMessagesViewController(capsuleId: capsuleId)
         navigationController.pushViewController(vc, animated: true)
     }
 }

--- a/Projects/Feature/MemoryFeature/Sources/DIContainer/MemoryDIContainer.swift
+++ b/Projects/Feature/MemoryFeature/Sources/DIContainer/MemoryDIContainer.swift
@@ -3,6 +3,8 @@ import Foundation
 import MemoryPresentation
 import BaseData
 import BaseDomain
+import MemoryData
+import MemoryDomain
 
 public final class MemoryDIContainer {
     private func makeMemoryViewModel(action: MemoryViewModel.Action, capsuleId: Int) -> MemoryViewModel {
@@ -47,13 +49,27 @@ public final class MemoryDIContainer {
 
     // MARK: - MyMemoryMessages
 
-    public func makeMyMemoryMessagesViewController() -> MyMemoryMessagesViewController {
-        let viewModel = MyMemoryMessagesViewModel()
+    public func makeMyMemoryMessagesViewController(capsuleId: Int) -> MyMemoryMessagesViewController {
+        let viewModel = makeMyMemoryMessagesViewModel(capsuleId: capsuleId)
         let textListVC = MyMemoryMessageListViewController(type: .text, viewModel: viewModel)
         let photoListVC = MyMemoryMessageListViewController(type: .photo, viewModel: viewModel)
         return MyMemoryMessagesViewController(
             viewControllers: [textListVC, photoListVC],
             with: viewModel
+        )
+    }
+
+    private func makeMyMemoryMessagesViewModel(capsuleId: Int) -> MyMemoryMessagesViewModel {
+        let provider = DefaultProvider<CapsuleContentTargetType>()
+        let userDefaultStorage = DefaultUserDefaultStorage()
+        let repository = DefaultCapsuleContentRepository(
+            provider: provider,
+            userDefaultStorage: userDefaultStorage
+        )
+        let useCase = DefaultCapsuleContentUseCase(capsuleContentRepository: repository)
+        return MyMemoryMessagesViewModel(
+            capsuleId: capsuleId,
+            capsuleContentUseCase: useCase
         )
     }
 }

--- a/Projects/Presentation/MemoryPresentation/Project.swift
+++ b/Projects/Presentation/MemoryPresentation/Project.swift
@@ -12,7 +12,8 @@ let project = Project.makeModule(
     name: "MemoryPresentation",
     product: .staticFramework,
     dependencies: [
-        .Presentation.BasePresentation
+        .Presentation.BasePresentation,
+        .Domain.MemoryDomain
     ],
     resources: ["Resources/**"]
 )

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessageListViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessageListViewController.swift
@@ -17,6 +17,8 @@ public final class MyMemoryMessageListViewController: UIViewController {
     private let type: MyMemoryMessageType
     private let disposeBag: DisposeBag = DisposeBag()
 
+    
+    
     private var textItems: [CapsuleContent] = []
     private var photoUrls: [String] = []
 
@@ -301,8 +303,7 @@ extension MyMemoryMessageListViewController {
             let sheet = MessageInputBottomSheet(initialText: text)
             sheet.didSubmitText
                 .subscribe(onNext: { [weak self] newText in
-                    let updated = MyMemoryMessage(type: .text, textContent: newText, imageData: nil)
-                    self?.viewModel.appendMessage(updated)
+                    self?.viewModel.createTextContent(newText)
                 })
                 .disposed(by: self.disposeBag)
             self.present(sheet, animated: true)

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessageListViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessageListViewController.swift
@@ -3,7 +3,9 @@ import SnapKit
 import RxSwift
 import RxCocoa
 import RxRelay
+
 import DesignSystem
+import MemoryDomain
 
 // MARK: - MyMemoryMessageListViewController
 
@@ -14,9 +16,13 @@ public final class MyMemoryMessageListViewController: UIViewController {
     private let viewModel: MyMemoryMessagesViewModel
     private let type: MyMemoryMessageType
     private let disposeBag: DisposeBag = DisposeBag()
-    private var items: [MyMemoryMessage] = []
+
+    private var textItems: [CapsuleContent] = []
+    private var photoUrls: [String] = []
+
     private var isSelectionMode: Bool = false
-    private var selectedItemIds: Set<UUID> = []
+    private var selectedTextIds: Set<Int> = []
+    private var selectedPhotoUrls: Set<String> = []
 
     public var onSelectionModeChanged: ((Bool) -> Void)?
 
@@ -101,7 +107,8 @@ public final class MyMemoryMessageListViewController: UIViewController {
     public func enterSelectionMode() {
         guard !isSelectionMode else { return }
         isSelectionMode = true
-        selectedItemIds.removeAll()
+        selectedTextIds.removeAll()
+        selectedPhotoUrls.removeAll()
         actionBarView.isHidden = false
         updateDeleteButtonState()
         updateCollectionViewLayoutConstraints()
@@ -112,7 +119,8 @@ public final class MyMemoryMessageListViewController: UIViewController {
     public func exitSelectionMode() {
         guard isSelectionMode else { return }
         isSelectionMode = false
-        selectedItemIds.removeAll()
+        selectedTextIds.removeAll()
+        selectedPhotoUrls.removeAll()
         actionBarView.isHidden = true
         updateCollectionViewLayoutConstraints()
         collectionView.reloadData()
@@ -186,17 +194,30 @@ extension MyMemoryMessageListViewController {
 
 extension MyMemoryMessageListViewController {
     private func bindViewModel() {
-        viewModel.messages(of: type)
-            .drive(onNext: { [weak self] items in
-                guard let self else { return }
-                self.items = items
-                self.selectedItemIds = self.selectedItemIds.filter { id in
-                    items.contains(where: { $0.id == id })
-                }
-                self.updateDeleteButtonState()
-                self.collectionView.reloadData()
-            })
-            .disposed(by: disposeBag)
+        switch type {
+        case .text:
+            viewModel.textContents()
+                .drive(onNext: { [weak self] items in
+                    guard let self else { return }
+                    self.textItems = items
+                    let validIds = Set(items.map { $0.id })
+                    self.selectedTextIds = self.selectedTextIds.intersection(validIds)
+                    self.updateDeleteButtonState()
+                    self.collectionView.reloadData()
+                })
+                .disposed(by: disposeBag)
+        case .photo:
+            viewModel.photoImageUrls()
+                .drive(onNext: { [weak self] urls in
+                    guard let self else { return }
+                    self.photoUrls = urls
+                    let validUrls = Set(urls)
+                    self.selectedPhotoUrls = self.selectedPhotoUrls.intersection(validUrls)
+                    self.updateDeleteButtonState()
+                    self.collectionView.reloadData()
+                })
+                .disposed(by: disposeBag)
+        }
     }
 
     private func bindButton() {
@@ -214,15 +235,30 @@ extension MyMemoryMessageListViewController {
         deleteButton.rx.tap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
-                guard !self.selectedItemIds.isEmpty else { return }
-                self.viewModel.deleteMessages(withIds: self.selectedItemIds)
-                self.exitSelectionMode()
+                self.handleDeleteTap()
             })
             .disposed(by: disposeBag)
     }
 
+    private func handleDeleteTap() {
+        switch type {
+        case .text:
+            guard !selectedTextIds.isEmpty else { return }
+            viewModel.deleteTextContents(selectedTextIds)
+        case .photo:
+            guard !selectedPhotoUrls.isEmpty else { return }
+            viewModel.deletePhotoUrls(selectedPhotoUrls)
+        }
+        exitSelectionMode()
+    }
+
     private func updateDeleteButtonState() {
-        let hasSelection = !selectedItemIds.isEmpty
+        let hasSelection: Bool = {
+            switch type {
+            case .text: return !selectedTextIds.isEmpty
+            case .photo: return !selectedPhotoUrls.isEmpty
+            }
+        }()
         deleteButton.isEnabled = hasSelection
         let activeColor = UIColor(red: 237/255, green: 30/255, blue: 47/255, alpha: 1.0)
         let disabledColor = UIColor(red: 243/255, green: 187/255, blue: 187/255, alpha: 1.0)
@@ -257,31 +293,31 @@ extension MyMemoryMessageListViewController {
         present(alert, animated: true)
     }
 
-    private func showItemPreview(for message: MyMemoryMessage) {
-        switch message.type {
-        case .text:
-            let modal = MessageDetailModalViewController(messageText: message.textContent ?? "")
-            modal.onEditTap = { [weak self] text in
-                guard let self else { return }
-                let sheet = MessageInputBottomSheet(initialText: text)
-                sheet.didSubmitText
-                    .subscribe(onNext: { [weak self] newText in
-                        let updated = MyMemoryMessage(type: .text, textContent: newText, imageData: nil)
-                        self?.viewModel.appendMessage(updated)
-                    })
-                    .disposed(by: self.disposeBag)
-                self.present(sheet, animated: true)
-            }
-            present(modal, animated: true)
-        case .photo:
-            let alert = UIAlertController(
-                title: "사진 미리보기",
-                message: nil,
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "닫기", style: .default))
-            present(alert, animated: true)
+    private func showTextPreview(for content: CapsuleContent) {
+        guard case .text(_, let value) = content else { return }
+        let modal = MessageDetailModalViewController(messageText: value)
+        modal.onEditTap = { [weak self] text in
+            guard let self else { return }
+            let sheet = MessageInputBottomSheet(initialText: text)
+            sheet.didSubmitText
+                .subscribe(onNext: { [weak self] newText in
+                    let updated = MyMemoryMessage(type: .text, textContent: newText, imageData: nil)
+                    self?.viewModel.appendMessage(updated)
+                })
+                .disposed(by: self.disposeBag)
+            self.present(sheet, animated: true)
         }
+        present(modal, animated: true)
+    }
+
+    private func showPhotoPreview() {
+        let alert = UIAlertController(
+            title: "사진 미리보기",
+            message: nil,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "닫기", style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -289,21 +325,38 @@ extension MyMemoryMessageListViewController {
 
 extension MyMemoryMessageListViewController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard indexPath.item < items.count else { return }
-        let message = items[indexPath.item]
-
-        if isSelectionMode {
-            if selectedItemIds.contains(message.id) {
-                selectedItemIds.remove(message.id)
-            } else {
-                selectedItemIds.insert(message.id)
+        switch type {
+        case .text:
+            guard indexPath.item < textItems.count else { return }
+            let content = textItems[indexPath.item]
+            let contentId = content.id
+            if isSelectionMode {
+                if selectedTextIds.contains(contentId) {
+                    selectedTextIds.remove(contentId)
+                } else {
+                    selectedTextIds.insert(contentId)
+                }
+                updateDeleteButtonState()
+                collectionView.reloadItems(at: [indexPath])
+                return
             }
-            updateDeleteButtonState()
-            collectionView.reloadItems(at: [indexPath])
-            return
-        }
+            showTextPreview(for: content)
 
-        showItemPreview(for: message)
+        case .photo:
+            guard indexPath.item < photoUrls.count else { return }
+            let url = photoUrls[indexPath.item]
+            if isSelectionMode {
+                if selectedPhotoUrls.contains(url) {
+                    selectedPhotoUrls.remove(url)
+                } else {
+                    selectedPhotoUrls.insert(url)
+                }
+                updateDeleteButtonState()
+                collectionView.reloadItems(at: [indexPath])
+                return
+            }
+            showPhotoPreview()
+        }
     }
 }
 
@@ -311,21 +364,24 @@ extension MyMemoryMessageListViewController: UICollectionViewDelegate {
 
 extension MyMemoryMessageListViewController: UICollectionViewDataSource {
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return items.count
+        switch type {
+        case .text: return textItems.count
+        case .photo: return photoUrls.count
+        }
     }
 
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let message = items[indexPath.item]
-        switch message.type {
+        switch type {
         case .text:
             let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: String(describing: MessageTextCardCell.self),
                 for: indexPath
             ) as? MessageTextCardCell
-            cell?.configure(with: message, index: indexPath.item + 1)
+            let content = textItems[indexPath.item]
+            cell?.configure(with: content, index: indexPath.item + 1)
             cell?.setSelection(
                 isSelectionMode: isSelectionMode,
-                isSelected: selectedItemIds.contains(message.id)
+                isSelected: selectedTextIds.contains(content.id)
             )
             return cell ?? UICollectionViewCell()
         case .photo:
@@ -333,10 +389,11 @@ extension MyMemoryMessageListViewController: UICollectionViewDataSource {
                 withReuseIdentifier: String(describing: MessagePhotoCardCell.self),
                 for: indexPath
             ) as? MessagePhotoCardCell
-            cell?.configure(with: message)
+            let url = photoUrls[indexPath.item]
+            cell?.configure(with: url)
             cell?.setSelection(
                 isSelectionMode: isSelectionMode,
-                isSelected: selectedItemIds.contains(message.id)
+                isSelected: selectedPhotoUrls.contains(url)
             )
             return cell ?? UICollectionViewCell()
         }

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessagesViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessagesViewController.swift
@@ -254,8 +254,7 @@ extension MyMemoryMessagesViewController {
         sheet.didSubmitText
             .withUnretained(self)
             .subscribe(onNext: { (self, text) in
-                let message = MyMemoryMessage(type: .text, textContent: text, imageData: nil)
-                self.viewModel.appendMessage(message)
+                self.viewModel.createTextContent(text)
             })
             .disposed(by: disposeBag)
         present(sheet, animated: true)
@@ -292,11 +291,8 @@ extension MyMemoryMessagesViewController: PHPickerViewControllerDelegate {
 
         group.notify(queue: .main) { [weak self] in
             guard let self else { return }
-            for data in orderedData {
-                guard let data else { continue }
-                let message = MyMemoryMessage(type: .photo, textContent: nil, imageData: data)
-                self.viewModel.appendMessage(message)
-            }
+            let images = orderedData.compactMap { $0 }
+            self.viewModel.createPhotoContent(images)
         }
     }
 

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessagesViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Controller/MyMemoryMessagesViewController.swift
@@ -120,6 +120,8 @@ public final class MyMemoryMessagesViewController: TabmanViewController {
         configureChildSelectionMode()
         bindButton()
 
+        viewModel.fetchContents()
+
         addBar(
             tabManBar,
             dataSource: self,

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Model/MyMemoryMessage.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/Model/MyMemoryMessage.swift
@@ -6,27 +6,3 @@ public enum MyMemoryMessageType {
     case text
     case photo
 }
-
-// MARK: - MyMemoryMessage
-
-public struct MyMemoryMessage {
-    public let id: UUID
-    public let type: MyMemoryMessageType
-    public let textContent: String?
-    public let imageData: Data?
-    public let createdAt: Date
-
-    public init(
-        id: UUID = UUID(),
-        type: MyMemoryMessageType,
-        textContent: String? = nil,
-        imageData: Data? = nil,
-        createdAt: Date = Date()
-    ) {
-        self.id = id
-        self.type = type
-        self.textContent = textContent
-        self.imageData = imageData
-        self.createdAt = createdAt
-    }
-}

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/View/Cell/MessagePhotoCardCell.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/View/Cell/MessagePhotoCardCell.swift
@@ -1,5 +1,7 @@
 import UIKit
 import SnapKit
+import Kingfisher
+
 import DesignSystem
 
 // MARK: - MessagePhotoCardCell
@@ -51,16 +53,16 @@ public final class MessagePhotoCardCell: UICollectionViewCell {
 
     public override func prepareForReuse() {
         super.prepareForReuse()
+        thumbnailImageView.kf.cancelDownloadTask()
         thumbnailImageView.image = nil
         selectionIconView.isHidden = true
         selectionIconView.image = nil
         selectionBorderView.isHidden = true
     }
 
-    public func configure(with message: MyMemoryMessage) {
-        if let data = message.imageData, let image = UIImage(data: data) {
-            thumbnailImageView.image = image
-        }
+    public func configure(with imageUrl: String) {
+        let url = URL(string: imageUrl)
+        thumbnailImageView.kf.setImage(with: url)
     }
 
     public func setSelection(isSelectionMode: Bool, isSelected: Bool) {

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/View/Cell/MessageTextCardCell.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/View/Cell/MessageTextCardCell.swift
@@ -1,6 +1,8 @@
 import UIKit
 import SnapKit
+
 import DesignSystem
+import MemoryDomain
 
 // MARK: - MessageTextCardCell
 
@@ -74,8 +76,15 @@ public final class MessageTextCardCell: UICollectionViewCell {
         selectionIconView.image = nil
     }
 
-    public func configure(with message: MyMemoryMessage, index: Int) {
+    public func configure(with content: CapsuleContent, index: Int) {
         titleLabel.text = "메세지 \(index)"
+
+        let text: String
+        if case .text(_, let value) = content {
+            text = value
+        } else {
+            text = ""
+        }
 
         let style = NSMutableParagraphStyle()
         style.lineHeightMultiple = 1.5
@@ -85,7 +94,7 @@ public final class MessageTextCardCell: UICollectionViewCell {
             .foregroundColor: UIColor(red: 69/255, green: 69/255, blue: 69/255, alpha: 1.0)
         ]
         bodyLabel.attributedText = NSAttributedString(
-            string: message.textContent ?? "",
+            string: text,
             attributes: attributes
         )
     }

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
@@ -3,31 +3,90 @@ import RxSwift
 import RxCocoa
 import RxRelay
 
+import MemoryDomain
+
 public final class MyMemoryMessagesViewModel {
 
     // MARK: - Properties
 
-    private let messages: BehaviorRelay<[MyMemoryMessage]> = BehaviorRelay(value: [])
+    private let capsuleId: Int
+    private let capsuleContentUseCase: CapsuleContentUseCase
+    private let contents: BehaviorRelay<[CapsuleContent]> = BehaviorRelay(value: [])
 
     // MARK: - Init
 
-    public init() {}
+    public init(capsuleId: Int, capsuleContentUseCase: CapsuleContentUseCase) {
+        self.capsuleId = capsuleId
+        self.capsuleContentUseCase = capsuleContentUseCase
+    }
 
-    // MARK: - Public
+    // MARK: - Fetch
 
-    public func messages(of type: MyMemoryMessageType) -> Driver<[MyMemoryMessage]> {
-        return messages
-            .map { items in items.filter { $0.type == type } }
+    public func fetchContents() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await capsuleContentUseCase.execute(capsuleId: capsuleId)
+                await MainActor.run {
+                    self.contents.accept(result)
+                }
+            } catch {
+                print("fetchContents error:", error)
+            }
+        }
+    }
+
+    // MARK: - Output
+
+    public func textContents() -> Driver<[CapsuleContent]> {
+        return contents
+            .map { items in
+                items.filter {
+                    if case .text = $0 { return true }
+                    return false
+                }
+            }
             .asDriver(onErrorJustReturn: [])
     }
 
-    public func appendMessage(_ message: MyMemoryMessage) {
-        messages.accept(messages.value + [message])
+    public func photoImageUrls() -> Driver<[String]> {
+        return contents
+            .map { items in
+                items.flatMap { item -> [String] in
+                    if case .photo(_, let imageUrls) = item { return imageUrls }
+                    return []
+                }
+            }
+            .asDriver(onErrorJustReturn: [])
     }
 
-    public func deleteMessages(withIds ids: Set<UUID>) {
+    // MARK: - Write (placeholder)
+
+    public func appendMessage(_ message: MyMemoryMessage) {}
+
+    // MARK: - Delete
+
+    public func deleteTextContents(_ ids: Set<Int>) {
         guard !ids.isEmpty else { return }
-        let remaining = messages.value.filter { !ids.contains($0.id) }
-        messages.accept(remaining)
+        let remaining = contents.value.filter { item in
+            if case .text(let id, _) = item {
+                return !ids.contains(id)
+            }
+            return true
+        }
+        contents.accept(remaining)
+    }
+
+    public func deletePhotoUrls(_ urls: Set<String>) {
+        guard !urls.isEmpty else { return }
+        let updated = contents.value.compactMap { item -> CapsuleContent? in
+            if case .photo(let id, let imageUrls) = item {
+                let remaining = imageUrls.filter { !urls.contains($0) }
+                if remaining.isEmpty { return nil }
+                return .photo(id: id, imageUrls: remaining)
+            }
+            return item
+        }
+        contents.accept(updated)
     }
 }

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
@@ -60,9 +60,36 @@ public final class MyMemoryMessagesViewModel {
             .asDriver(onErrorJustReturn: [])
     }
 
-    // MARK: - Write (placeholder)
+    // MARK: - Create
 
-    public func appendMessage(_ message: MyMemoryMessage) {}
+    public func createTextContent(_ text: String) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let created = try await capsuleContentUseCase.createText(capsuleId: capsuleId, content: text)
+                await MainActor.run {
+                    self.contents.accept(self.contents.value + [created])
+                }
+            } catch {
+                print("createTextContent error:", error)
+            }
+        }
+    }
+
+    public func createPhotoContent(_ images: [Data]) {
+        guard !images.isEmpty else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let created = try await capsuleContentUseCase.createPhotos(capsuleId: capsuleId, images: images)
+                await MainActor.run {
+                    self.contents.accept(self.contents.value + [created])
+                }
+            } catch {
+                print("createPhotoContent error:", error)
+            }
+        }
+    }
 
     // MARK: - Delete
 

--- a/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/MyMemoryMessages/ViewModel/MyMemoryMessagesViewModel.swift
@@ -95,25 +95,54 @@ public final class MyMemoryMessagesViewModel {
 
     public func deleteTextContents(_ ids: Set<Int>) {
         guard !ids.isEmpty else { return }
-        let remaining = contents.value.filter { item in
-            if case .text(let id, _) = item {
-                return !ids.contains(id)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                for id in ids {
+                    try await capsuleContentUseCase.delete(contentId: id)
+                }
+                await MainActor.run {
+                    let remaining = self.contents.value.filter { item in
+                        if case .text(let id, _) = item {
+                            return !ids.contains(id)
+                        }
+                        return true
+                    }
+                    self.contents.accept(remaining)
+                }
+            } catch {
+                print("deleteTextContents error:", error)
             }
-            return true
         }
-        contents.accept(remaining)
     }
 
     public func deletePhotoUrls(_ urls: Set<String>) {
         guard !urls.isEmpty else { return }
-        let updated = contents.value.compactMap { item -> CapsuleContent? in
+        let contentIds: Set<Int> = Set(contents.value.compactMap { item -> Int? in
             if case .photo(let id, let imageUrls) = item {
-                let remaining = imageUrls.filter { !urls.contains($0) }
-                if remaining.isEmpty { return nil }
-                return .photo(id: id, imageUrls: remaining)
+                return imageUrls.contains(where: { urls.contains($0) }) ? id : nil
             }
-            return item
+            return nil
+        })
+        guard !contentIds.isEmpty else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                for id in contentIds {
+                    try await capsuleContentUseCase.delete(contentId: id)
+                }
+                await MainActor.run {
+                    let remaining = self.contents.value.filter { item in
+                        if case .photo(let id, _) = item {
+                            return !contentIds.contains(id)
+                        }
+                        return true
+                    }
+                    self.contents.accept(remaining)
+                }
+            } catch {
+                print("deletePhotoUrls error:", error)
+            }
         }
-        contents.accept(updated)
     }
 }

--- a/Tuist/ProjectDescriptionHelpers/Dependency+Project.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency+Project.swift
@@ -42,6 +42,11 @@ public extension TargetDependency.Data {
         target: "CreateTicketData",
         path: .relativeToRoot("Projects/Data/CreateTicketData")
     )
+
+    static let MemoryData = TargetDependency.project(
+        target: "MemoryData",
+        path: .relativeToRoot("Projects/Data/MemoryData")
+    )
 }
 
 public extension TargetDependency.Domain {
@@ -74,6 +79,11 @@ public extension TargetDependency.Domain {
     static let CreateTicketDomain = TargetDependency.project(
         target: "CreateTicketDomain",
         path: .relativeToRoot("Projects/Domain/CreateTicketDomain")
+    )
+
+    static let MemoryDomain = TargetDependency.project(
+        target: "MemoryDomain",
+        path: .relativeToRoot("Projects/Domain/MemoryDomain")
     )
 }
 


### PR DESCRIPTION
## 변경 사항

  ### Domain / Data 모듈 신규 추가
  - `MemoryDomain` 모듈 추가 (Entity / UseCase / Repository Protocol / Error)
  - `MemoryData` 모듈 추가 (TargetType / RequestDTO / ResponseDTO / Default Repository)

  ### API 연동
  - `GET /api/time-capsule-content/{capsuleId}/contents` — 추억 메시지 조회 (현재 유저의 텍스트/사진
  컨텐츠 필터링)
  - `POST /api/time-capsule-content/{capsuleId}` — 텍스트/사진 컨텐츠 생성 (multipart 업로드)
  - `DELETE /api/time-capsule-content/{contentId}` — 컨텐츠 삭제 (statusCode 204)

  ### UI / Presentation
  - `MyMemoryMessagesViewController` (Tabman 기반 메세지/사진 탭) 신규 구현
  - `MyMemoryMessageListViewController` — 텍스트/사진 리스트, 선택 모드, 일괄 삭제 UI
  - `MessageInputBottomSheet`, `MessageDetailModalViewController`, `MessagePhotoCardCell`,
  `MessageTextCardCell`, `MessageTypeBannerView` 추가
  - DesignSystem 에 메모리 관련 아이콘 에셋 추가 (TrashIcon, MessagePhotoIcon, MessageTextIcon,
  Selected/Unselected 아이콘 등)

  ### Feature
  - `MemoryDIContainer` / `MemoryCoordinator` 에 `MyMemoryMessages` 화면 진입 경로 및 의존성 조립 추가