### PR TITLE
Feature: 티켓 생성 - 오픈 날짜 제거

### DIFF
--- a/Projects/Data/CreateTicketData/Sources/Repository/DefaultCreateTicketRepository.swift
+++ b/Projects/Data/CreateTicketData/Sources/Repository/DefaultCreateTicketRepository.swift
@@ -22,21 +22,14 @@ public final class DefaultCreateTicketRepository: CreateTicketRepository {
     public func createTicket(
         title: String,
         description: String?,
-        openedAt: Date,
         mainImage: Data
     ) async throws {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm"
 
         let requestDTO = CreateTicketRequestDTO(
             title: title,
-            description: description,
-            openedAt: dateFormatter.string(from: openedAt)
+            description: description
         )
         
-        print(requestDTO)
-
         let result = await provider.request(.createTicket(requestDTO, mainImage: mainImage))
 
         try ResultHandler.handleResult(

--- a/Projects/Data/CreateTicketData/Sources/RequestDTO/CreateTicketRequestDTO.swift
+++ b/Projects/Data/CreateTicketData/Sources/RequestDTO/CreateTicketRequestDTO.swift
@@ -11,11 +11,9 @@ import Foundation
 public struct CreateTicketRequestDTO: Encodable {
     let title: String
     let description: String?
-    let openedAt: String
 
-    public init(title: String, description: String?, openedAt: String) {
+    public init(title: String, description: String?) {
         self.title = title
         self.description = description
-        self.openedAt = openedAt
     }
 }

--- a/Projects/Domain/CreateTicketDomain/Sources/Repository/CreateTicketRepository.swift
+++ b/Projects/Domain/CreateTicketDomain/Sources/Repository/CreateTicketRepository.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol CreateTicketRepository {
-    func createTicket(title: String, description: String?, openedAt: Date, mainImage: Data) async throws
+    func createTicket(title: String, description: String?, mainImage: Data) async throws
 }

--- a/Projects/Domain/CreateTicketDomain/Sources/UseCase/CreateTicketUseCase.swift
+++ b/Projects/Domain/CreateTicketDomain/Sources/UseCase/CreateTicketUseCase.swift
@@ -14,7 +14,6 @@ public protocol CreateTicketUseCase {
     func execute(
         title: String,
         description: String?,
-        openedAt: Date,
         mainImage: Data
     ) async throws
 }
@@ -30,13 +29,11 @@ public final class DefaultCreateTicketUseCase: CreateTicketUseCase {
     public func execute(
         title: String,
         description: String?, 
-        openedAt: Date,
         mainImage: Data
     ) async throws {
         try await createTicketRepository.createTicket(
             title: title,
             description: description,
-            openedAt: openedAt,
             mainImage: mainImage
         )
     }

--- a/Projects/Feature/CreateTicketFeature/Sources/DIContainer/CreateTicketDIContainer.swift
+++ b/Projects/Feature/CreateTicketFeature/Sources/DIContainer/CreateTicketDIContainer.swift
@@ -8,16 +8,12 @@
 
 import Foundation
 
-import CalendarDomain
 import CreateTicketDomain
 import CreateTicketData
 import BaseData
 import CreateTicketPresentation
 
 public final class CreateTicketDIContainer {
-    private func makeCalendarUseCase() -> CalendarUseCase {
-        return DefaultCalendarUseCase()
-    }
 
     private func makeCreateTicketProvider() -> DefaultProvider<CreateTicketTargetType> {
         return DefaultProvider<CreateTicketTargetType>()
@@ -33,7 +29,6 @@ public final class CreateTicketDIContainer {
 
     private func makeCreateTicketViewModel(action: CreateTicketViewModel.Action) -> CreateTicketViewModel {
         return CreateTicketViewModel(
-            calendarUseCase: makeCalendarUseCase(),
             createTicketUseCase: makeCreateTicketUseCase(),
             action: action
         )

--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/Controller/CreateTicketViewController.swift
@@ -28,27 +28,16 @@ public final class CreateTicketViewController: UIViewController {
     private let viewModel: CreateTicketViewModel
     private let disposeBag: DisposeBag = DisposeBag()
 
-    private let rxViewDidLoad: PublishRelay<Void> = .init()
     private let imageSelectedRelay: PublishRelay<UIImage> = .init()
-    private let selectedDateRelay: PublishRelay<Date> = .init()
-    private var currentCalendarDates: [CalendarDateModel] = []
 
     private var ticketImageWavyLayer: WavyStrokeLayer?
     private var ticketTitleWavyLayer: WavyStrokeLayer?
     private var descriptionWavyLayer: WavyStrokeLayer?
-    private var calendarWavyLayer: WavyStrokeLayer?
 
     private let navigationView: MemorySealNavigationView = {
         let view = MemorySealNavigationView()
         view.setTitle("타임 티켓 생성하기")
         return view
-    }()
-
-    private let scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.backgroundColor = .clear
-        scrollView.showsHorizontalScrollIndicator = false
-        return scrollView
     }()
 
     private let photoTitleLabel: UILabel = {
@@ -121,20 +110,6 @@ public final class CreateTicketViewController: UIViewController {
         return label
     }()
 
-    private let calendarTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "오픈 날짜"
-        label.textColor = DesignSystemAsset.ColorAssests.grey3.color
-        label.font = DesignSystemFontFamily.Pretendard.medium.font(size: 12)
-        return label
-    }()
-
-    private let calendarView: MemorySealCalendarView = {
-        let view = MemorySealCalendarView()
-        view.layer.cornerRadius = 12
-        return view
-    }()
-
     private let createButtonWavyBackground: WavyStrokeView = {
         let view = WavyStrokeView(
             fillColor: DesignSystemAsset.ColorAssests.primaryNormal.color,
@@ -175,11 +150,10 @@ public final class CreateTicketViewController: UIViewController {
         self.setupWavyStrokeLayers()
 
         self.bindViewModel()
-        self.bindScrollView()
+        self.bindSView()
         self.bindTextView()
         self.bindTextFieldFocus()
         self.bindImagePicker()
-        self.rxViewDidLoad.accept(())
     }
 
     public override func viewDidLayoutSubviews() {
@@ -187,7 +161,6 @@ public final class CreateTicketViewController: UIViewController {
         syncWavyStrokeLayer(ticketImageWavyLayer, to: ticketImageContainer.bounds)
         syncWavyStrokeLayer(ticketTitleWavyLayer, to: ticketTitleTextField.bounds)
         syncWavyStrokeLayer(descriptionWavyLayer, to: descriptionTextView.bounds)
-        syncWavyStrokeLayer(calendarWavyLayer, to: calendarView.bounds)
     }
 
     private func syncWavyStrokeLayer(_ layer: WavyStrokeLayer?, to bounds: CGRect) {
@@ -209,63 +182,13 @@ public final class CreateTicketViewController: UIViewController {
 extension CreateTicketViewController {
     private func bindViewModel() {
         let input = CreateTicketViewModel.Input(
-            rxViewDidLoad: rxViewDidLoad,
             navigationViewBackButtonDidTap: navigationView.backButtonDidTap,
-            previousMonthButtonDidTap: calendarView.previousMonthButtonDidTap,
-            nextMonthButtonDidTap: calendarView.nextMonthButtonDidTap,
             createButtonDidTap: createButton.rx.tap,
             titleText: ticketTitleTextField.rx.text,
             descriptionText: descriptionTextView.rx.text,
-            selectedImage: imageSelectedRelay,
-            selectedDate: selectedDateRelay
+            selectedImage: imageSelectedRelay
         )
         let output = viewModel.transform(input)
-
-        output.currentMonth
-            .withUnretained(self)
-            .subscribe(onNext: { (self, date) in
-                self.calendarView.setTitleLabel(date: date)
-            })
-            .disposed(by: disposeBag)
-
-        output.calendarDates
-            .withUnretained(self)
-            .subscribe(onNext: { (self, dates) in
-                self.currentCalendarDates = dates
-            })
-            .disposed(by: disposeBag)
-
-        output.calendarDates
-            .bind(to: calendarView.collectionView.rx.items(
-                cellIdentifier: MemorySealCalendarCollectionViewCell.reuseIdentifier,
-                cellType: MemorySealCalendarCollectionViewCell.self
-            )) { (index, item, cell) in
-                let dateFormatter = DateFormatter()
-                dateFormatter.locale = Locale(identifier: "en_US")
-                dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-                dateFormatter.dateFormat = "d"
-                let dateText: String = dateFormatter.string(from: item.date)
-
-                cell.configure(
-                    dateText: dateText,
-                    isCurrentMonth: item.isInCurrentMonth,
-                    isToday: item.isToday
-                )
-
-                if index > 30 {
-                    self.calendarView.remakeCollectionViewLayout()
-                }
-            }
-            .disposed(by: disposeBag)
-
-        calendarView.collectionView.rx.itemSelected
-            .withUnretained(self)
-            .subscribe(onNext: { (self, indexPath) in
-                guard indexPath.item < self.currentCalendarDates.count else { return }
-                let date = self.currentCalendarDates[indexPath.item].date
-                self.selectedDateRelay.accept(date)
-            })
-            .disposed(by: disposeBag)
 
         output.canCreate
             .drive(with: self) { (self, canCreate) in
@@ -295,17 +218,10 @@ extension CreateTicketViewController {
         }
     }
 
-    private func bindScrollView() {
-        scrollView.rx.contentOffset
-            .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                self.view.endEditing(true)
-            })
-            .disposed(by: disposeBag)
-
+    private func bindSView() {
         let backgroundTap = UITapGestureRecognizer()
         backgroundTap.cancelsTouchesInView = false
-        scrollView.addGestureRecognizer(backgroundTap)
+        view.addGestureRecognizer(backgroundTap)
 
         backgroundTap.rx.event
             .withUnretained(self)
@@ -458,17 +374,6 @@ extension CreateTicketViewController {
             cornerRadius: 12,
             alignment: .outside
         )
-        calendarWavyLayer = calendarView.addWavyStrokeLayer(
-            strokeColor: inactiveColor,
-            lineWidth: 3,
-            cornerRadius: 12,
-            alignment: .outside
-        )
-
-        calendarView.onLayoutSubviews = { [weak self] in
-            guard let self else { return }
-            self.syncWavyStrokeLayer(self.calendarWavyLayer, to: self.calendarView.bounds)
-        }
 
         descriptionTextView.onLayoutSubviews = { [weak self] in
             guard let self else { return }
@@ -478,24 +383,20 @@ extension CreateTicketViewController {
 
     private func addSubviews() {
         view.addSubview(navigationView)
-        view.addSubview(scrollView)
 
-        scrollView.addSubview(photoTitleLabel)
-        scrollView.addSubview(ticketImageContainer)
+        view.addSubview(photoTitleLabel)
+        view.addSubview(ticketImageContainer)
         ticketImageContainer.addSubview(ticketImageView)
 
-        scrollView.addSubview(ticketTitleLabel)
-        scrollView.addSubview(ticketTitleTextField)
+        view.addSubview(ticketTitleLabel)
+        view.addSubview(ticketTitleTextField)
 
-        scrollView.addSubview(descriptionTitleLabel)
-        scrollView.addSubview(descriptionTextView)
-        scrollView.addSubview(descriptionPlaceholderLabel)
+        view.addSubview(descriptionTitleLabel)
+        view.addSubview(descriptionTextView)
+        view.addSubview(descriptionPlaceholderLabel)
 
-        scrollView.addSubview(calendarTitleLabel)
-        scrollView.addSubview(calendarView)
-
-        scrollView.addSubview(createButtonWavyBackground)
-        scrollView.addSubview(createButton)
+        view.addSubview(createButtonWavyBackground)
+        view.addSubview(createButton)
     }
 
     private func setLayout() {
@@ -505,16 +406,8 @@ extension CreateTicketViewController {
             $0.height.equalTo(56)
         }
 
-        scrollView.snp.makeConstraints {
-            $0.top.equalTo(navigationView.snp.bottom)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
-            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing)
-            $0.width.equalTo(view.frame.width)
-        }
-
         photoTitleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(24)
+            $0.top.equalTo(navigationView.snp.bottom).offset(12)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(26)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(26)
         }
@@ -560,23 +453,10 @@ extension CreateTicketViewController {
             $0.leading.equalTo(descriptionTextView.snp.leading).offset(15)
         }
 
-        calendarTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(descriptionTextView.snp.bottom).offset(16)
-            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(26)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(26)
-        }
-
-        calendarView.snp.makeConstraints {
-            $0.top.equalTo(calendarTitleLabel.snp.bottom).offset(8)
-            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(20)
-        }
-
         createButton.snp.makeConstraints {
-            $0.top.equalTo(calendarView.snp.bottom).offset(24)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(20)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(20)
-            $0.bottom.equalTo(scrollView.snp.bottom).inset(24)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(24)
             $0.height.equalTo(48)
         }
 

--- a/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/ViewModel/CreateTicketViewModel.swift
+++ b/Projects/Presentation/CreateTicketPresentation/Sources/CreateTicket/ViewModel/CreateTicketViewModel.swift
@@ -10,7 +10,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-import CalendarDomain
 import CreateTicketDomain
 import DesignSystem
 
@@ -24,42 +23,29 @@ public final class CreateTicketViewModel {
     }
 
     private let disposeBag: DisposeBag = DisposeBag()
-    private let calendarUseCase: CalendarUseCase
     private let createTicketUseCase: CreateTicketUseCase
 
     public let action: Action
 
     private var storedImage: UIImage?
-    private var storedDate: Date = Date().kstNow
-
-    private let currentMonth: BehaviorRelay<Date> = .init(value: Date().kstNow)
-    private let calendarDates: PublishRelay<[CalendarDateModel]> = .init()
 
     public init(
-        calendarUseCase: CalendarUseCase,
         createTicketUseCase: CreateTicketUseCase,
         action: Action
     ) {
-        self.calendarUseCase = calendarUseCase
         self.createTicketUseCase = createTicketUseCase
         self.action = action
     }
 
     struct Input {
-        let rxViewDidLoad: PublishRelay<Void>
         let navigationViewBackButtonDidTap: ControlEvent<Void>
-        let previousMonthButtonDidTap: ControlEvent<Void>
-        let nextMonthButtonDidTap: ControlEvent<Void>
         let createButtonDidTap: ControlEvent<Void>
         let titleText: ControlProperty<String?>
         let descriptionText: ControlProperty<String?>
         let selectedImage: PublishRelay<UIImage>
-        let selectedDate: PublishRelay<Date>
     }
 
     struct Output {
-        let currentMonth: BehaviorRelay<Date>
-        let calendarDates: PublishRelay<[CalendarDateModel]>
         let isLoading: BehaviorRelay<Bool>
         let canCreate: Driver<Bool>
     }
@@ -68,41 +54,10 @@ public final class CreateTicketViewModel {
         let isLoading = BehaviorRelay<Bool>(value: false)
         let imageSelectedRelay = BehaviorRelay<Bool>(value: false)
 
-        input.rxViewDidLoad
-            .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                self.requestCalendarDates(date: Date().kstNow)
-            })
-            .disposed(by: disposeBag)
-
         input.navigationViewBackButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
                 self.action.popViewController()
-            })
-            .disposed(by: disposeBag)
-
-        input.previousMonthButtonDidTap
-            .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                var calendar = Calendar(identifier: .gregorian)
-                calendar.locale = Locale(identifier: "en_US")
-                calendar.timeZone = TimeZone(abbreviation: "UTC") ?? .current
-                if let previousMonth = calendar.date(byAdding: .month, value: -1, to: self.currentMonth.value) {
-                    self.requestCalendarDates(date: previousMonth)
-                }
-            })
-            .disposed(by: disposeBag)
-
-        input.nextMonthButtonDidTap
-            .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                var calendar = Calendar(identifier: .gregorian)
-                calendar.locale = Locale(identifier: "en_US")
-                calendar.timeZone = TimeZone(abbreviation: "UTC") ?? .current
-                if let nextMonth = calendar.date(byAdding: .month, value: 1, to: self.currentMonth.value) {
-                    self.requestCalendarDates(date: nextMonth)
-                }
             })
             .disposed(by: disposeBag)
 
@@ -111,13 +66,6 @@ public final class CreateTicketViewModel {
             .subscribe(onNext: { (self, image) in
                 self.storedImage = image
                 imageSelectedRelay.accept(true)
-            })
-            .disposed(by: disposeBag)
-
-        input.selectedDate
-            .withUnretained(self)
-            .subscribe(onNext: { (self, date) in
-                self.storedDate = date
             })
             .disposed(by: disposeBag)
 
@@ -135,7 +83,6 @@ public final class CreateTicketViewModel {
                 self.requestCreateTicket(
                     title: title,
                     description: desc,
-                    openedAt: self.storedDate,
                     mainImage: imageData,
                     isLoading: isLoading
                 )
@@ -156,8 +103,6 @@ public final class CreateTicketViewModel {
         .asDriver(onErrorJustReturn: false)
 
         return Output(
-            currentMonth: currentMonth,
-            calendarDates: calendarDates,
             isLoading: isLoading,
             canCreate: canCreate
         )
@@ -165,16 +110,9 @@ public final class CreateTicketViewModel {
 }
 
 extension CreateTicketViewModel {
-    private func requestCalendarDates(date: Date) {
-        let calendarDates: [CalendarDateModel] = calendarUseCase.generateCalendarDates(for: date)
-        self.calendarDates.accept(calendarDates)
-        self.currentMonth.accept(date)
-    }
-
     private func requestCreateTicket(
         title: String,
         description: String?,
-        openedAt: Date,
         mainImage: Data,
         isLoading: BehaviorRelay<Bool>
     ) {
@@ -184,7 +122,6 @@ extension CreateTicketViewModel {
                 try await createTicketUseCase.execute(
                     title: title,
                     description: description,
-                    openedAt: openedAt,
                     mainImage: mainImage
                 )
                 await MainActor.run {


### PR DESCRIPTION
## 변경 사항

### Data
- `CreateTicketRequestDTO` 에서 `openedAt` 필드 제거
- `DefaultCreateTicketRepository.createTicket` 시그니처에서 `openedAt` 제거 및 관련 `DateFormatter` 로직 제거

### Domain
- `CreateTicketRepository` 프로토콜에서 `openedAt: Date` 파라미터 제거
- `CreateTicketUseCase.execute` 시그니처에서 `openedAt` 제거

### Feature
- `CreateTicketDIContainer` 에서 `CalendarUseCase` 의존성 제거 (캘린더 사용처가 사라짐)

### Presentation
- `CreateTicketViewController` 에서 오픈 날짜 캘린더 UI 제거 (`calendarTitleLabel`, `calendarView`, `calendarWavyLayer`)
- 스크롤뷰 제거 후 루트 `view` 에 직접 서브뷰 배치로 레이아웃 단순화
- 생성 버튼 위치를 캘린더 하단 → 화면 하단(safeArea 24pt 위)으로 변경
- `CreateTicketViewModel` 에서 캘린더 관련 Input/Output, 월 이동 처리, `storedDate` 등 제거
- `CalendarDomain` import 제거

## 테스트 방법

- [ ] 티켓 생성 화면 진입 시 사진 / 제목 / 소개 입력 영역만 노출되고 캘린더가 보이지 않는지 확인
- [ ] 사진 선택, 제목 입력 시 생성 버튼이 활성화되는지 확인
- [ ] 생성 버튼 탭 → 백엔드 요청 페이로드에 `openedAt` 키가 포함되지 않은 채 정상 응답되는지 확인 (네트워크 로그)
- [ ] 생성 성공 시 이전 화면으로 정상 pop 되는지 확인
- [ ] 뒤로가기 버튼이 정상 동작하는지 확인
- [ ] 키보드 외부 영역 탭 시 키보드가 정상적으로 내려가는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)