### PR TITLE
Feature: 티켓 묻기 모달 + PUT /time-capsules/{capsuleId}/bury 연동

### DIFF
--- a/Projects/Data/MemoryData/Sources/Repository/DefaultBuryTicketRepository.swift
+++ b/Projects/Data/MemoryData/Sources/Repository/DefaultBuryTicketRepository.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+import BaseData
+import MemoryDomain
+
+public final class DefaultBuryTicketRepository: BuryTicketRepository {
+
+    private let provider: DefaultProvider<BuryTicketTargetType>
+
+    public init(provider: DefaultProvider<BuryTicketTargetType>) {
+        self.provider = provider
+    }
+
+    public func buryTimeCapsule(capsuleId: Int, openedAt: Date) async throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        let openedAtString = formatter.string(from: openedAt)
+
+        let requestDTO = BuryTicketRequestDTO(openedAt: openedAtString)
+        let result = await provider.request(
+            .buryTimeCapsule(capsuleId: capsuleId, requestDTO: requestDTO)
+        )
+        try ResultHandler.handleResult(result: result, errorType: BuryTicketError.self)
+    }
+}

--- a/Projects/Data/MemoryData/Sources/RequestDTO/BuryTicketRequestDTO.swift
+++ b/Projects/Data/MemoryData/Sources/RequestDTO/BuryTicketRequestDTO.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct BuryTicketRequestDTO: Encodable {
+    let openedAt: String
+
+    public init(openedAt: String) {
+        self.openedAt = openedAt
+    }
+}

--- a/Projects/Data/MemoryData/Sources/TargetType/BuryTicketTargetType.swift
+++ b/Projects/Data/MemoryData/Sources/TargetType/BuryTicketTargetType.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Moya
+
+import BaseData
+
+public enum BuryTicketTargetType {
+    case buryTimeCapsule(capsuleId: Int, requestDTO: BuryTicketRequestDTO)
+}
+
+extension BuryTicketTargetType: BaseTargetType {
+    public var path: String {
+        switch self {
+        case .buryTimeCapsule(let capsuleId, _):
+            return "/time-capsules/\(capsuleId)/bury"
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .buryTimeCapsule:
+            return .put
+        }
+    }
+
+    public var task: Moya.Task {
+        switch self {
+        case .buryTimeCapsule(_, let requestDTO):
+            return .requestJSONEncodable(requestDTO)
+        }
+    }
+
+    public var headers: [String: String]? {
+        return nil
+    }
+
+    public var isNeededAccessToken: Bool {
+        switch self {
+        case .buryTimeCapsule:
+            return true
+        }
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/Error/BuryTicketError.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Error/BuryTicketError.swift
@@ -1,0 +1,9 @@
+import BaseDomain
+
+public enum BuryTicketError: DomainError {
+    case defaultError
+
+    public init(errorResponse: BaseDomain.ErrorResponseEntity) {
+        self = .defaultError
+    }
+}

--- a/Projects/Domain/MemoryDomain/Sources/Repository/BuryTicketRepository.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Repository/BuryTicketRepository.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol BuryTicketRepository {
+    func buryTimeCapsule(capsuleId: Int, openedAt: Date) async throws
+}

--- a/Projects/Domain/MemoryDomain/Sources/UseCase/BuryTicketUseCase.swift
+++ b/Projects/Domain/MemoryDomain/Sources/UseCase/BuryTicketUseCase.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol BuryTicketUseCase {
+    func buryTimeCapsule(capsuleId: Int, openedAt: Date) async throws
+}
+
+public final class DefaultBuryTicketUseCase: BuryTicketUseCase {
+    private let buryTicketRepository: BuryTicketRepository
+
+    public init(buryTicketRepository: BuryTicketRepository) {
+        self.buryTicketRepository = buryTicketRepository
+    }
+
+    public func buryTimeCapsule(capsuleId: Int, openedAt: Date) async throws {
+        try await buryTicketRepository.buryTimeCapsule(capsuleId: capsuleId, openedAt: openedAt)
+    }
+}

--- a/Projects/Feature/MemoryFeature/Project.swift
+++ b/Projects/Feature/MemoryFeature/Project.swift
@@ -14,6 +14,7 @@ let project = Project.makeModule(
     dependencies: [
         .Presentation.MemoryPresentation,
         .Data.BaseData,
-        .Data.MemoryData
+        .Data.MemoryData,
+        .Domain.CalendarDomain
     ]
 )

--- a/Projects/Feature/MemoryFeature/Sources/Coordinator/MemoryCoordinator.swift
+++ b/Projects/Feature/MemoryFeature/Sources/Coordinator/MemoryCoordinator.swift
@@ -21,7 +21,8 @@ public final class MemoryCoordinator {
         let memoryAction = MemoryViewModel.Action(
             moveToAddMember: moveToAddMember,
             moveToManageTicket: moveToManageTicket,
-            moveToMyMemoryMessages: moveToMyMemoryMessages
+            moveToMyMemoryMessages: moveToMyMemoryMessages,
+            moveToBuryTicket: moveToBuryTicket
         )
         let memoryViewController = memoryDIContainer.makeMemoryViewController(action: memoryAction, capsuleId: capsuleId)
 
@@ -29,6 +30,19 @@ public final class MemoryCoordinator {
             memoryViewController,
             animated: true
         )
+    }
+
+    public func moveToBuryTicket() {
+        let buryAction = BuryTicketViewModel.Action(
+            dismiss: { [weak self] in
+                self?.navigationController.presentedViewController?.dismiss(animated: true)
+            }
+        )
+        let viewController = memoryDIContainer.makeBuryTicketViewController(
+            action: buryAction,
+            capsuleId: capsuleId
+        )
+        self.navigationController.present(viewController, animated: true)
     }
 
     public func moveToAddMember() {

--- a/Projects/Feature/MemoryFeature/Sources/DIContainer/MemoryDIContainer.swift
+++ b/Projects/Feature/MemoryFeature/Sources/DIContainer/MemoryDIContainer.swift
@@ -5,6 +5,7 @@ import BaseData
 import BaseDomain
 import MemoryData
 import MemoryDomain
+import CalendarDomain
 
 public final class MemoryDIContainer {
     private func makeMemoryViewModel(action: MemoryViewModel.Action, capsuleId: Int) -> MemoryViewModel {
@@ -45,6 +46,25 @@ public final class MemoryDIContainer {
 
     func makeManageTicketViewController(action: ManageTicketViewModel.Action, capsuleId: Int, ticketName: String) -> ManageTicketViewController {
         return ManageTicketViewController(with: makeManageTicketViewModel(action: action, capsuleId: capsuleId, ticketName: ticketName))
+    }
+
+    // MARK: - BuryTicket
+
+    private func makeBuryTicketViewModel(action: BuryTicketViewModel.Action, capsuleId: Int) -> BuryTicketViewModel {
+        let calendarUseCase = DefaultCalendarUseCase()
+        let provider = DefaultProvider<BuryTicketTargetType>()
+        let repository = DefaultBuryTicketRepository(provider: provider)
+        let buryTicketUseCase = DefaultBuryTicketUseCase(buryTicketRepository: repository)
+        return BuryTicketViewModel(
+            action: action,
+            capsuleId: capsuleId,
+            calendarUseCase: calendarUseCase,
+            buryTicketUseCase: buryTicketUseCase
+        )
+    }
+
+    func makeBuryTicketViewController(action: BuryTicketViewModel.Action, capsuleId: Int) -> BuryTicketViewController {
+        return BuryTicketViewController(with: makeBuryTicketViewModel(action: action, capsuleId: capsuleId))
     }
 
     // MARK: - MyMemoryMessages

--- a/Projects/Feature/SplashFeature/Tests/placeHolder.swift
+++ b/Projects/Feature/SplashFeature/Tests/placeHolder.swift
@@ -1,0 +1,8 @@
+//
+//  placeHolder.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 선민재 on 9/26/24.
+//
+
+import Foundation

--- a/Projects/Presentation/MemoryPresentation/Project.swift
+++ b/Projects/Presentation/MemoryPresentation/Project.swift
@@ -13,7 +13,8 @@ let project = Project.makeModule(
     product: .staticFramework,
     dependencies: [
         .Presentation.BasePresentation,
-        .Domain.MemoryDomain
+        .Domain.MemoryDomain,
+        .Domain.CalendarDomain
     ],
     resources: ["Resources/**"]
 )

--- a/Projects/Presentation/MemoryPresentation/Sources/BuryTicket/Controller/BuryTicketViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/BuryTicket/Controller/BuryTicketViewController.swift
@@ -1,0 +1,265 @@
+import UIKit
+
+import SnapKit
+import RxSwift
+import RxCocoa
+
+import CalendarDomain
+import DesignSystem
+
+public final class BuryTicketViewController: UIViewController {
+    private let viewModel: BuryTicketViewModel
+    private let disposeBag: DisposeBag = DisposeBag()
+
+    private let rxViewDidLoad: PublishRelay<Void> = .init()
+    private let didSelectDate: PublishRelay<Date> = .init()
+    private var currentCalendarDates: [CalendarDateModel] = []
+
+    // MARK: - Subviews
+
+    private let dimView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(red: 68/255, green: 68/255, blue: 68/255, alpha: 0.24)
+        return view
+    }()
+
+    private let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 12
+        view.clipsToBounds = true
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "티켓 오픈일 설정"
+        label.font = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
+        label.textColor = .black
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "한번 묻은 티켓은 오픈일까지 다시 오픈,\n수정 할 수 없습니다."
+        label.font = DesignSystemFontFamily.Pretendard.regular.font(size: 16)
+        label.textColor = DesignSystemAsset.ColorAssests.grey3.color
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private let calendarView: MemorySealCalendarView = {
+        let view = MemorySealCalendarView()
+        view.layer.cornerRadius = 12
+        view.layer.borderWidth = 1
+        view.layer.borderColor = DesignSystemAsset.ColorAssests.grey1.color.cgColor
+        return view
+    }()
+
+    private let cancelButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setTitle("취소", for: .normal)
+        button.setTitleColor(DesignSystemAsset.ColorAssests.grey4.color, for: .normal)
+        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        button.backgroundColor = DesignSystemAsset.ColorAssests.grey1.color
+        button.layer.cornerRadius = 12
+        return button
+    }()
+
+    private let buryButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setTitle("묻기", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+        button.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
+        button.layer.cornerRadius = 12
+        return button
+    }()
+
+    private let buttonStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.distribution = .fillEqually
+        return stack
+    }()
+
+    // MARK: - Init
+
+    public init(with viewModel: BuryTicketViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .clear
+
+        self.addSubviews()
+        self.setLayout()
+        self.bindViewModel()
+        self.bindDimView()
+
+        self.rxViewDidLoad.accept(())
+    }
+}
+
+// MARK: - Subviews
+
+extension BuryTicketViewController {
+    private func addSubviews() {
+        view.addSubview(dimView)
+        view.addSubview(containerView)
+        containerView.addSubview(titleLabel)
+        containerView.addSubview(descriptionLabel)
+        containerView.addSubview(calendarView)
+        buttonStackView.addArrangedSubview(cancelButton)
+        buttonStackView.addArrangedSubview(buryButton)
+        containerView.addSubview(buttonStackView)
+    }
+
+    private func setLayout() {
+        dimView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        containerView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(32)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+
+        buttonStackView.snp.makeConstraints {
+            $0.top.equalTo(calendarView.snp.bottom).offset(32)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+        }
+    }
+}
+
+// MARK: - Bind
+
+extension BuryTicketViewController {
+    private func bindViewModel() {
+        let input = BuryTicketViewModel.Input(
+            rxViewDidLoad: rxViewDidLoad,
+            previousMonthButtonDidTap: calendarView.previousMonthButtonDidTap,
+            nextMonthButtonDidTap: calendarView.nextMonthButtonDidTap,
+            didSelectDate: didSelectDate,
+            cancelButtonDidTap: cancelButton.rx.tap,
+            buryButtonDidTap: buryButton.rx.tap
+        )
+        let output = viewModel.transform(input)
+
+        output.currentMonth
+            .withUnretained(self)
+            .subscribe(onNext: { (self, date) in
+                self.calendarView.setTitleLabel(date: date)
+            })
+            .disposed(by: disposeBag)
+
+        output.calendarDates
+            .withUnretained(self)
+            .subscribe(onNext: { (self, dates) in
+                self.currentCalendarDates = dates
+            })
+            .disposed(by: disposeBag)
+
+        output.calendarDates
+            .bind(to: calendarView.collectionView.rx.items(
+                cellIdentifier: MemorySealCalendarCollectionViewCell.reuseIdentifier,
+                cellType: MemorySealCalendarCollectionViewCell.self
+            )) { (index, item, cell) in
+                let dateFormatter = DateFormatter()
+                dateFormatter.locale = Locale(identifier: "en_US")
+                dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+                dateFormatter.dateFormat = "d"
+                let dateText: String = dateFormatter.string(from: item.date)
+
+                cell.configure(
+                    dateText: dateText,
+                    isCurrentMonth: item.isInCurrentMonth,
+                    isToday: item.isToday
+                )
+
+                if index > 30 {
+                    self.calendarView.remakeCollectionViewLayout()
+                }
+            }
+            .disposed(by: disposeBag)
+
+        calendarView.collectionView.rx.itemSelected
+            .withUnretained(self)
+            .subscribe(onNext: { (self, indexPath) in
+                guard indexPath.item < self.currentCalendarDates.count else { return }
+                let date = self.currentCalendarDates[indexPath.item].date
+                self.didSelectDate.accept(date)
+            })
+            .disposed(by: disposeBag)
+
+        output.canBury
+            .drive(with: self) { (self, canBury) in
+                self.applyBuryButtonState(enabled: canBury)
+            }
+            .disposed(by: disposeBag)
+
+        output.isLoading
+            .drive(with: self) { (self, isLoading) in
+                self.view.isUserInteractionEnabled = !isLoading
+            }
+            .disposed(by: disposeBag)
+
+        output.errorMessage
+            .emit(with: self) { (self, message) in
+                ToastView.show(on: self.view, message: message)
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func applyBuryButtonState(enabled: Bool) {
+        buryButton.isEnabled = enabled
+        if enabled {
+            buryButton.backgroundColor = DesignSystemAsset.ColorAssests.primaryNormal.color
+            buryButton.setTitleColor(.white, for: .normal)
+        } else {
+            buryButton.backgroundColor = DesignSystemAsset.ColorAssests.primaryLight.color
+            buryButton.setTitleColor(.white, for: .normal)
+        }
+    }
+
+    private func bindDimView() {
+        let tapGesture = UITapGestureRecognizer()
+        dimView.addGestureRecognizer(tapGesture)
+
+        tapGesture.rx.event
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                self.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/Projects/Presentation/MemoryPresentation/Sources/BuryTicket/ViewModel/BuryTicketViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/BuryTicket/ViewModel/BuryTicketViewModel.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+import CalendarDomain
+import MemoryDomain
+import DesignSystem
+
+public final class BuryTicketViewModel {
+    private let disposeBag: DisposeBag = DisposeBag()
+
+    public struct Action {
+        public let dismiss: () -> Void
+
+        public init(dismiss: @escaping () -> Void) {
+            self.dismiss = dismiss
+        }
+    }
+
+    public let action: Action
+
+    private let capsuleId: Int
+    private let calendarUseCase: CalendarUseCase
+    private let buryTicketUseCase: BuryTicketUseCase
+
+    private let currentMonth: BehaviorRelay<Date> = .init(value: Date().kstNow)
+    private let calendarDates: PublishRelay<[CalendarDateModel]> = .init()
+    private let selectedDate: BehaviorRelay<Date?> = .init(value: nil)
+
+    public init(
+        action: Action,
+        capsuleId: Int,
+        calendarUseCase: CalendarUseCase,
+        buryTicketUseCase: BuryTicketUseCase
+    ) {
+        self.action = action
+        self.capsuleId = capsuleId
+        self.calendarUseCase = calendarUseCase
+        self.buryTicketUseCase = buryTicketUseCase
+    }
+
+    struct Input {
+        let rxViewDidLoad: PublishRelay<Void>
+        let previousMonthButtonDidTap: ControlEvent<Void>
+        let nextMonthButtonDidTap: ControlEvent<Void>
+        let didSelectDate: PublishRelay<Date>
+        let cancelButtonDidTap: ControlEvent<Void>
+        let buryButtonDidTap: ControlEvent<Void>
+    }
+
+    struct Output {
+        let currentMonth: BehaviorRelay<Date>
+        let calendarDates: PublishRelay<[CalendarDateModel]>
+        let selectedDate: BehaviorRelay<Date?>
+        let canBury: Driver<Bool>
+        let isLoading: Driver<Bool>
+        let errorMessage: Signal<String>
+    }
+
+    func transform(_ input: Input) -> Output {
+        let isLoading = BehaviorRelay<Bool>(value: false)
+        let errorMessage = PublishRelay<String>()
+
+        input.rxViewDidLoad
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                self.requestCalendarDates(date: self.currentMonth.value)
+            })
+            .disposed(by: disposeBag)
+
+        input.previousMonthButtonDidTap
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                var calendar = Calendar(identifier: .gregorian)
+                calendar.locale = Locale(identifier: "en_US")
+                calendar.timeZone = TimeZone(abbreviation: "UTC") ?? .current
+                if let previousMonth = calendar.date(byAdding: .month, value: -1, to: self.currentMonth.value) {
+                    self.requestCalendarDates(date: previousMonth)
+                }
+            })
+            .disposed(by: disposeBag)
+
+        input.nextMonthButtonDidTap
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                var calendar = Calendar(identifier: .gregorian)
+                calendar.locale = Locale(identifier: "en_US")
+                calendar.timeZone = TimeZone(abbreviation: "UTC") ?? .current
+                if let nextMonth = calendar.date(byAdding: .month, value: 1, to: self.currentMonth.value) {
+                    self.requestCalendarDates(date: nextMonth)
+                }
+            })
+            .disposed(by: disposeBag)
+
+        input.didSelectDate
+            .bind(to: selectedDate)
+            .disposed(by: disposeBag)
+
+        input.cancelButtonDidTap
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                self.action.dismiss()
+            })
+            .disposed(by: disposeBag)
+
+        input.buryButtonDidTap
+            .withLatestFrom(selectedDate)
+            .compactMap { $0 }
+            .withUnretained(self)
+            .subscribe(onNext: { (self, date) in
+                guard isLoading.value == false else { return }
+                isLoading.accept(true)
+                Task {
+                    do {
+                        try await self.buryTicketUseCase.buryTimeCapsule(
+                            capsuleId: self.capsuleId,
+                            openedAt: date
+                        )
+                        await MainActor.run {
+                            isLoading.accept(false)
+                            self.action.dismiss()
+                        }
+                    } catch {
+                        await MainActor.run {
+                            isLoading.accept(false)
+                            errorMessage.accept("티켓을 묻는 중 오류가 발생했습니다.")
+                        }
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
+        let canBury = Observable
+            .combineLatest(selectedDate, isLoading)
+            .map { date, loading in
+                date != nil && loading == false
+            }
+            .asDriver(onErrorJustReturn: false)
+
+        return Output(
+            currentMonth: currentMonth,
+            calendarDates: calendarDates,
+            selectedDate: selectedDate,
+            canBury: canBury,
+            isLoading: isLoading.asDriver(),
+            errorMessage: errorMessage.asSignal()
+        )
+    }
+}
+
+extension BuryTicketViewModel {
+    private func requestCalendarDates(date: Date) {
+        let calendarDates: [CalendarDateModel] = calendarUseCase.generateCalendarDates(for: date)
+        self.calendarDates.accept(calendarDates)
+        self.currentMonth.accept(date)
+    }
+}

--- a/Projects/Presentation/MemoryPresentation/Sources/Memory/Controller/MemoryViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/Memory/Controller/MemoryViewController.swift
@@ -278,7 +278,8 @@ extension MemoryViewController {
             rxViewDidLoad: rxViewDidLoad,
             didTapAddMemberButton: didTapAddMemberButton,
             didTapManageButton: didTapManageButton,
-            didTapSeeMessagesButton: didTapSeeMessagesButton
+            didTapSeeMessagesButton: didTapSeeMessagesButton,
+            didTapBuryTicketButton: didTapBuryTicketButton
         )
         let _ = viewModel.transform(input)
     }

--- a/Projects/Presentation/MemoryPresentation/Sources/Memory/ViewModel/MemoryViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/Memory/ViewModel/MemoryViewModel.swift
@@ -16,15 +16,18 @@ public final class MemoryViewModel {
         public let moveToAddMember: () -> Void
         public let moveToManageTicket: () -> Void
         public let moveToMyMemoryMessages: () -> Void
+        public let moveToBuryTicket: () -> Void
 
         public init(
             moveToAddMember: @escaping () -> Void,
             moveToManageTicket: @escaping () -> Void,
-            moveToMyMemoryMessages: @escaping () -> Void
+            moveToMyMemoryMessages: @escaping () -> Void,
+            moveToBuryTicket: @escaping () -> Void
         ) {
             self.moveToAddMember = moveToAddMember
             self.moveToManageTicket = moveToManageTicket
             self.moveToMyMemoryMessages = moveToMyMemoryMessages
+            self.moveToBuryTicket = moveToBuryTicket
         }
     }
 
@@ -42,6 +45,7 @@ public final class MemoryViewModel {
         let didTapAddMemberButton: PublishRelay<Void>
         let didTapManageButton: PublishRelay<Void>
         let didTapSeeMessagesButton: PublishRelay<Void>
+        let didTapBuryTicketButton: PublishRelay<Void>
     }
 
     struct Output {
@@ -75,6 +79,13 @@ public final class MemoryViewModel {
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
                 self.action.moveToMyMemoryMessages()
+            })
+            .disposed(by: disposeBag)
+
+        input.didTapBuryTicketButton
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                self.action.moveToBuryTicket()
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Presentation/SplashPresentation/Tests/placeHolder.swift
+++ b/Projects/Presentation/SplashPresentation/Tests/placeHolder.swift
@@ -1,0 +1,8 @@
+//
+//  placeHolder.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 선민재 on 9/26/24.
+//
+
+import Foundation


### PR DESCRIPTION
## Summary
- Memory 화면의 "티켓 묻기" 버튼 탭 시 캘린더 모달을 띄워 오픈일을 고르고 `PUT /time-capsules/{capsuleId}/bury` API로 봉인하는 흐름 추가
- DesignSystem `MemorySealCalendarView` + `CalendarDomain.DefaultCalendarUseCase` 재사용
- 날짜 미선택 / 호출 중에는 묻기 버튼 비활성, 실패 시 `ToastView` 노출, 성공 시 dismiss
- `MemoryDomain` / `MemoryData`에 BuryTicket 모듈 신설 (Repository / UseCase / Error / RequestDTO / TargetType)
- `MemoryPresentation` / `MemoryFeature`에 `CalendarDomain` 의존성 추가
- 부수: `SplashFeature` / `SplashPresentation`의 Tests 디렉토리 누락으로 `tuist generate`가 실패하던 이슈 해결 (placeHolder.swift 추가)

## Request Body
```json
{ "openedAt": "2026-05-26T11:22:38.016Z" }
```
선택한 캘린더 일자(UTC 00:00 기준)를 ISO8601 + fractional seconds 포맷으로 직렬화하여 전송.

## Test plan
- [ ] `make generate` 후 빌드 성공
- [ ] Memory 화면 진입 → "티켓 묻기" 탭 → 모달 dim + 캘린더 표시
- [ ] 월 이전/다음 버튼으로 이동 가능
- [ ] 날짜 선택 전: 묻기 버튼 비활성(primaryLight), 선택 후: 활성(primaryNormal)
- [ ] 취소 버튼 또는 dim 영역 탭 → 모달 dismiss
- [ ] 묻기 버튼 탭 → API 호출 → 성공 시 모달 dismiss, 실패 시 토스트 표시
- [ ] 호출 중 view 인터랙션 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)