### PR TITLE
Fix: 티켓 나가기 HOST_CANNOT_LEAVE 에러 다이얼로그 처리

### DIFF
--- a/Projects/Data/BaseData/Sources/ResponseDTO/ErrorResponseDTO.swift
+++ b/Projects/Data/BaseData/Sources/ResponseDTO/ErrorResponseDTO.swift
@@ -11,14 +11,14 @@ import Foundation
 import BaseDomain
 
 struct ErrorResponseDTO: Decodable {
-    let status: String?
+    let status: Int?
     let error: String?
     let message: String?
     let path: String?
 
     var toDomain: ErrorResponseEntity {
         return .init(
-            status: status ?? "",
+            status: status ?? 0,
             error: error ?? "",
             message: message ?? "",
             path: path ?? ""

--- a/Projects/Domain/BaseDomain/Sources/Entity/Error/ErrorResponseEntity.swift
+++ b/Projects/Domain/BaseDomain/Sources/Entity/Error/ErrorResponseEntity.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 public struct ErrorResponseEntity: Equatable {
-    public let status: String
+    public let status: Int
     public let error: String
     public let message: String
     public let path: String
 
-    public init(status: String, error: String, message: String, path: String) {
+    public init(status: Int, error: String, message: String, path: String) {
         self.status = status
         self.error = error
         self.message = message

--- a/Projects/Domain/MemoryDomain/Sources/Error/ManageTicketError.swift
+++ b/Projects/Domain/MemoryDomain/Sources/Error/ManageTicketError.swift
@@ -1,9 +1,15 @@
 import BaseDomain
 
 public enum ManageTicketError: DomainError {
+    case hostCannotLeave
     case defaultError
 
     public init(errorResponse: BaseDomain.ErrorResponseEntity) {
-        self = .defaultError
+        switch errorResponse.error {
+        case "HOST_CANNOT_LEAVE":
+            self = .hostCannotLeave
+        default:
+            self = .defaultError
+        }
     }
 }

--- a/Projects/Presentation/MemoryPresentation/Sources/ManageTicket/Controller/ManageTicketViewController.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/ManageTicket/Controller/ManageTicketViewController.swift
@@ -78,12 +78,32 @@ extension ManageTicketViewController {
             didConfirmDelete: didConfirmDelete,
             didConfirmLeave: didConfirmLeave
         )
-        let _ = viewModel.transform(input)
+        let output = viewModel.transform(input)
 
         navigationView.backButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
                 self.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        output.hostCannotLeave
+            .emit(with: self) { (self, _) in
+                self.showHostCannotLeaveDialog()
+            }
+            .disposed(by: disposeBag)
+    }
+
+    private func showHostCannotLeaveDialog() {
+        let dialog = DialogView.show(
+            on: self.view,
+            title: "방장은 방장 권한을 위임 혹은\n티켓에 아무도 없을때 티켓을\n나가실 수 있어요.",
+            confirmTitle: "확인"
+        )
+
+        dialog.confirmButtonDidTap
+            .subscribe(onNext: {
+                dialog.dismiss()
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/Presentation/MemoryPresentation/Sources/ManageTicket/ViewModel/ManageTicketViewModel.swift
+++ b/Projects/Presentation/MemoryPresentation/Sources/ManageTicket/ViewModel/ManageTicketViewModel.swift
@@ -53,11 +53,13 @@ public final class ManageTicketViewModel {
     struct Output {
         let deleteResult: Driver<Bool>
         let leaveResult: Driver<Bool>
+        let hostCannotLeave: Signal<Void>
     }
 
     func transform(_ input: Input) -> Output {
         let deleteResult = PublishRelay<Bool>()
         let leaveResult = PublishRelay<Bool>()
+        let hostCannotLeave = PublishRelay<Void>()
 
         input.didConfirmDelete
             .withUnretained(self)
@@ -88,6 +90,16 @@ public final class ManageTicketViewModel {
                             leaveResult.accept(true)
                             self.action.didLeaveTimeCapsule()
                         }
+                    } catch let error as ManageTicketError {
+                        await MainActor.run {
+                            switch error {
+                            case .hostCannotLeave:
+                                hostCannotLeave.accept(())
+                            case .defaultError:
+                                break
+                            }
+                            leaveResult.accept(false)
+                        }
                     } catch {
                         await MainActor.run {
                             leaveResult.accept(false)
@@ -99,7 +111,8 @@ public final class ManageTicketViewModel {
 
         return Output(
             deleteResult: deleteResult.asDriver(onErrorJustReturn: false),
-            leaveResult: leaveResult.asDriver(onErrorJustReturn: false)
+            leaveResult: leaveResult.asDriver(onErrorJustReturn: false),
+            hostCannotLeave: hostCannotLeave.asSignal()
         )
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Dialog/DialogView.swift
@@ -79,6 +79,13 @@ public final class DialogView: UIView {
 
     private let confirmButtonContainer = UIView()
 
+    private let wavyBackground: WavyStrokeView = {
+        let view = WavyStrokeView(fillColor: .white)
+        view.waveCornerRadius = 24
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
     private let buttonStackView: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
@@ -99,18 +106,42 @@ public final class DialogView: UIView {
 
     public init(
         title: String,
-        message: String,
-        cancelTitle: String,
+        message: String? = nil,
+        cancelTitle: String? = nil,
         confirmTitle: String
     ) {
         super.init(frame: .zero)
-        titleLabel.text = title
-        messageLabel.text = message
-        cancelButton.setTitle(cancelTitle, for: .normal)
+
+        if cancelTitle == nil {
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineHeightMultiple = 1.5
+            paragraphStyle.alignment = .center
+            titleLabel.attributedText = NSAttributedString(
+                string: title,
+                attributes: [
+                    .font: DesignSystemFontFamily.Pretendard.bold.font(size: 20),
+                    .foregroundColor: UIColor.black,
+                    .paragraphStyle: paragraphStyle
+                ]
+            )
+        } else {
+            titleLabel.text = title
+        }
+
+        if let message = message {
+            messageLabel.text = message
+        } else {
+            messageLabel.isHidden = true
+        }
+
+        if let cancelTitle = cancelTitle {
+            cancelButton.setTitle(cancelTitle, for: .normal)
+        } else {
+            cancelButtonContainer.isHidden = true
+        }
         confirmButton.setTitle(confirmTitle, for: .normal)
 
-        self.backgroundColor = .white
-        self.layer.cornerRadius = 24
+        self.backgroundColor = .clear
 
         self.addSubviews()
         self.setLayout()
@@ -124,8 +155,8 @@ public final class DialogView: UIView {
     public static func show(
         on view: UIView,
         title: String,
-        message: String,
-        cancelTitle: String,
+        message: String? = nil,
+        cancelTitle: String? = nil,
         confirmTitle: String
     ) -> DialogView {
         let dialog = DialogView(
@@ -183,6 +214,8 @@ public final class DialogView: UIView {
 
 extension DialogView {
     private func addSubviews() {
+        addSubview(wavyBackground)
+
         textStackView.addArrangedSubview(titleLabel)
         textStackView.addArrangedSubview(messageLabel)
 
@@ -199,6 +232,10 @@ extension DialogView {
     }
 
     private func setLayout() {
+        wavyBackground.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
         textStackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(28)
             $0.leading.trailing.equalToSuperview().inset(24)


### PR DESCRIPTION
## Summary
  - `DELETE /time-capsules/{capsuleId}/leave` 가 `HOST_CANNOT_LEAVE` 400 응답 시 Figma 디자인(906:19267)대로 단일 확인
  버튼 다이얼로그 표시
  - 공용 `DialogView` 를 1버튼 / 2버튼 모두 지원하도록 확장 (`cancelTitle`·`message` 옵셔널)
  - `DialogView` 외곽 컨테이너 wavy 배경(`WavyStrokeView .filled`) 적용
  - 서버 응답 `status` 가 `Int` 인데 DTO 가 `String?` 으로 잡혀 있어 JSON 디코딩이 통째로 실패하던 버그 수정 → 에러
  매핑이 동작하지 않아 다이얼로그 트리거 누락되던 근본 원인

  ## 주요 변경
  - `ErrorResponseDTO.status` / `ErrorResponseEntity.status` `String → Int`
  - `ManageTicketError` 에 `.hostCannotLeave` 케이스 추가, `errorResponse.error == "HOST_CANNOT_LEAVE"` 매핑
  - `ManageTicketViewModel.Output` 에 `hostCannotLeave: Signal<Void>` 추가, leave catch 분기 처리
  - `ManageTicketViewController` 에서 시그널 구독 → `DialogView.show(... confirmTitle: "확인")` 1버튼 모드로 다이얼로그
   표시
  - `DialogView`:
    - `init/show` 파라미터에서 `message` / `cancelTitle` 옵셔널 처리
    - 1버튼 모드 시 타이틀 center 정렬 + line-height 150% 자동 적용
    - 외곽 컨테이너에 `WavyStrokeView(.filled white, radius 24)` 백그라운드 삽입, 자체 `cornerRadius` 제거