### PR TITLE
Refactor: Coordinator의 Action 네이밍을 Dependency로 통일

### DIFF
--- a/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
+++ b/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
@@ -26,25 +26,25 @@ public final class AppCoordinator {
     }
 
     private func moveToAuthCoordinator() {
-        let action = AuthCoordinator.Action(
+        let dependency = AuthCoordinator.Dependency(
             authDidFinish: { [weak self] in
                 self?.authCoordinator = nil
                 self?.moveToMainCoordinator()
             }
         )
-        let coordinator = AuthCoordinator(with: navigationController, action: action)
+        let coordinator = AuthCoordinator(with: navigationController, dependency: dependency)
         authCoordinator = coordinator
         coordinator.start()
     }
 
     private func moveToMainCoordinator() {
-        let action = MainCoordinator.Action(
+        let dependency = MainCoordinator.Dependency(
             didRequestLogout: { [weak self] in
                 self?.mainCoordinator = nil
                 self?.moveToAuthCoordinator()
             }
         )
-        let coordinator = MainCoordinator(with: navigationController, action: action)
+        let coordinator = MainCoordinator(with: navigationController, dependency: dependency)
         mainCoordinator = coordinator
         coordinator.start()
     }

--- a/Projects/Feature/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/Projects/Feature/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -13,7 +13,7 @@ import SignInFeature
 import SignUpFeature
 
 public final class AuthCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let authDidFinish: () -> Void
 
         public init(authDidFinish: @escaping () -> Void) {
@@ -23,39 +23,39 @@ public final class AuthCoordinator {
 
     private let navigationController: UINavigationController
     private var splashCoordinator: SplashCoordinator?
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
-        let splashAction = SplashCoordinator.Action(
+        let splashDependency = SplashCoordinator.Dependency(
             moveToSignIn: moveToSignInCoordinator,
-            moveToHome: action.authDidFinish,
+            moveToHome: dependency.authDidFinish,
             moveToSignUp: moveToSignUpCoordinator
         )
-        let coordinator = SplashCoordinator(with: navigationController, action: splashAction)
+        let coordinator = SplashCoordinator(with: navigationController, dependency: splashDependency)
         splashCoordinator = coordinator
         coordinator.start()
     }
 
     private func moveToSignInCoordinator() {
         splashCoordinator = nil
-        let signInAction = SignInCoordinator.Action(
-            moveToHome: action.authDidFinish,
+        let signInDependency = SignInCoordinator.Dependency(
+            moveToHome: dependency.authDidFinish,
             moveToSignUp: moveToSignUpCoordinator
         )
-        let coordinator = SignInCoordinator(with: navigationController, action: signInAction)
+        let coordinator = SignInCoordinator(with: navigationController, dependency: signInDependency)
         coordinator.start()
     }
 
     private func moveToSignUpCoordinator() {
-        let signUpAction = SignUpCoordinator.Action(
-            moveToHome: action.authDidFinish
+        let signUpDependency = SignUpCoordinator.Dependency(
+            moveToHome: dependency.authDidFinish
         )
-        let coordinator = SignUpCoordinator(with: navigationController, action: signUpAction)
+        let coordinator = SignUpCoordinator(with: navigationController, dependency: signUpDependency)
         coordinator.start()
     }
 }

--- a/Projects/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -11,7 +11,7 @@ import HomePresentation
 import BaseDomain
 
 public final class HomeCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let moveToCreateTicket: () -> Void
         public let moveToProfile: () -> Void
         public let moveToMemory: (_ capsuleId: Int) -> Void
@@ -25,21 +25,21 @@ public final class HomeCoordinator {
 
     private let navigationController: UINavigationController
     private let homeDIContainer: HomeDIContainer = .init()
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
         let tabmanAction = HomeTabmanViewModel.Action(
-            moveToCreateTicket: action.moveToCreateTicket,
-            moveToProfile: action.moveToProfile,
+            moveToCreateTicket: dependency.moveToCreateTicket,
+            moveToProfile: dependency.moveToProfile,
             moveToEnterTicket: moveToEnterTicket
         )
 
-        let homeAction = HomeViewModel.Action(moveToMemory: action.moveToMemory)
+        let homeAction = HomeViewModel.Action(moveToMemory: dependency.moveToMemory)
 
         let hostHomeViewController = homeDIContainer.makeHomeViewController(action: homeAction, role: .host)
         let contributorHomeViewController = homeDIContainer.makeHomeViewController(action: homeAction, role: .contributor)

--- a/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
+++ b/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
@@ -14,7 +14,7 @@ import CreateTicketFeature
 import MemoryFeature
 
 public final class MainCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let didRequestLogout: () -> Void
 
         public init(didRequestLogout: @escaping () -> Void) {
@@ -25,35 +25,35 @@ public final class MainCoordinator {
     private let navigationController: UINavigationController
     private var profileCoordinator: ProfileCoordinator?
     private var memoryCoordinator: MemoryCoordinator?
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
-        let homeAction = HomeCoordinator.Action(
+        let homeDependency = HomeCoordinator.Dependency(
             moveToCreateTicket: moveToCreateTicketCoordinator,
             moveToProfile: moveToProfileCoordinator,
             moveToMemory: moveToMemoryCoordinator
         )
-        let coordinator = HomeCoordinator(with: navigationController, action: homeAction)
+        let coordinator = HomeCoordinator(with: navigationController, dependency: homeDependency)
         coordinator.start()
     }
 
     private func moveToProfileCoordinator() {
-        let profileAction = ProfileCoordinator.Action(
+        let profileDependency = ProfileCoordinator.Dependency(
             moveToBack: { [weak self] in
                 self?.navigationController.popViewController(animated: true)
                 self?.profileCoordinator = nil
             },
             didLogout: { [weak self] in
                 self?.profileCoordinator = nil
-                self?.action.didRequestLogout()
+                self?.dependency.didRequestLogout()
             }
         )
-        let coordinator = ProfileCoordinator(with: navigationController, action: profileAction)
+        let coordinator = ProfileCoordinator(with: navigationController, dependency: profileDependency)
         profileCoordinator = coordinator
         coordinator.start()
     }

--- a/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
+++ b/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 import ProfilePresentation
 
 public final class ProfileCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let moveToBack: () -> Void
         public let didLogout: () -> Void
 
@@ -23,16 +23,16 @@ public final class ProfileCoordinator {
 
     private let navigationController: UINavigationController
     private let profileDIContainer: ProfileDIContainer = .init()
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
         let profileAction = ProfileViewModel.Action(
-            moveToBack: action.moveToBack,
+            moveToBack: dependency.moveToBack,
             moveToEditProfile: moveToEditProfile,
             moveToSettings: moveToSettings
         )
@@ -60,8 +60,8 @@ public final class ProfileCoordinator {
         let settingsAction = SettingsViewModel.Action(
             moveToBack: popViewController,
             moveToTermsOfService: moveToTermsOfService,
-            moveToLogout: action.didLogout,
-            moveToWithdrawal: action.didLogout
+            moveToLogout: dependency.didLogout,
+            moveToWithdrawal: dependency.didLogout
         )
         let settingsViewController = profileDIContainer.makeSettingsViewController(action: settingsAction)
         self.navigationController.pushViewController(

--- a/Projects/Feature/SignInFeature/Sources/Coordinator/SignInCoordinator.swift
+++ b/Projects/Feature/SignInFeature/Sources/Coordinator/SignInCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 import SignInPresentation
 
 public final class SignInCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let moveToHome: () -> Void
         public let moveToSignUp: () -> Void
 
@@ -22,17 +22,17 @@ public final class SignInCoordinator {
 
     private let navigationController: UINavigationController
     private let signInDIContainer: SignInDIContainer = SignInDIContainer()
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
         let vmAction = SignInViewModel.Action(
-            moveToHome: action.moveToHome,
-            moveToSignUp: action.moveToSignUp
+            moveToHome: dependency.moveToHome,
+            moveToSignUp: dependency.moveToSignUp
         )
         let signInViewController = signInDIContainer.makeSignInViewController(action: vmAction)
 

--- a/Projects/Feature/SignUpFeature/Sources/Coordinator/SignUpCoordinator.swift
+++ b/Projects/Feature/SignUpFeature/Sources/Coordinator/SignUpCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 import SignUpPresentation
 
 public final class SignUpCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let moveToHome: () -> Void
 
         public init(moveToHome: @escaping () -> Void) {
@@ -20,16 +20,16 @@ public final class SignUpCoordinator {
 
     private let navigationController: UINavigationController
     private let signUpDIContainer: SignUpDIContainer = SignUpDIContainer()
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
         let vmAction = SignUpViewModel.Action(
-            moveToHome: action.moveToHome
+            moveToHome: dependency.moveToHome
         )
         let signUpViewController = signUpDIContainer.makeSignUpViewController(action: vmAction)
 

--- a/Projects/Feature/SplashFeature/Sources/Coordinator/SplashCoordinator.swift
+++ b/Projects/Feature/SplashFeature/Sources/Coordinator/SplashCoordinator.swift
@@ -11,7 +11,7 @@ import UIKit
 import SplashPresentation
 
 public final class SplashCoordinator {
-    public struct Action {
+    public struct Dependency {
         public let moveToSignIn: () -> Void
         public let moveToHome: () -> Void
         public let moveToSignUp: () -> Void
@@ -25,18 +25,18 @@ public final class SplashCoordinator {
 
     private let navigationController: UINavigationController
     private let splashDIContainer: SplashDIContainer = SplashDIContainer()
-    private let action: Action
+    private let dependency: Dependency
 
-    public init(with navigationController: UINavigationController, action: Action) {
+    public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
-        self.action = action
+        self.dependency = dependency
     }
 
     public func start() {
         let vmAction = SplashViewModel.Action(
-            moveToSignIn: action.moveToSignIn,
-            moveToHome: action.moveToHome,
-            moveToSignUp: action.moveToSignUp
+            moveToSignIn: dependency.moveToSignIn,
+            moveToHome: dependency.moveToHome,
+            moveToSignUp: dependency.moveToSignUp
         )
         let splashViewController = splashDIContainer.makeSplashViewController(action: vmAction)
 


### PR DESCRIPTION
## 변경 사항

- Coordinator의 부모 → 자식 이벤트 클로저 컨테이너를 `Action` → `Dependency` 로 리네임 (의존성 주입 의도 명확화)
- 대상 Coordinator 7개
  - `SplashCoordinator`
  - `SignInCoordinator`
  - `SignUpCoordinator`
  - `HomeCoordinator`
  - `ProfileCoordinator`
  - `AuthCoordinator`
  - `MainCoordinator`
- 함께 변경된 항목
  - 저장 프로퍼티 `action` → `dependency`
  - `init(...)` 파라미터 라벨 `action:` → `dependency:`
  - 호출부 (`AppCoordinator` / `AuthCoordinator` / `MainCoordinator`) 의 지역 변수 및 인자 라벨 일괄 갱신
- `ViewModel.Action` 은 의도적으로 유지 (Input/Output 패턴에서의 사용자 액션 의미는 그대로)

## 테스트 방법

- [ ] `tuist generate` 후 전체 빌드 성공 확인
- [ ] 앱 콜드 스타트 → Splash → 로그인 흐름 정상 진입 확인
- [ ] 로그인 → 홈 진입 확인
- [ ] 홈 → 프로필 → 로그아웃 → Auth 재진입 흐름 확인
- [ ] 홈 → 티켓 생성 / 메모리 진입 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)