### PR TITLE
[Feature] 멤버 화면 협력자 검색 기능 추가

### DIFF
--- a/Projects/Data/TicketData/Sources/Repository/DefaultAddMemberRepository.swift
+++ b/Projects/Data/TicketData/Sources/Repository/DefaultAddMemberRepository.swift
@@ -35,6 +35,18 @@ public final class DefaultAddMemberRepository: AddMemberRepository {
         return responseDTO.content.map { $0.toDomain }
     }
 
+    public func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity] {
+        let result = await provider.request(.searchCollaborators(capsuleId: capsuleId, nickname: nickname))
+
+        let responseDTO = try ResultHandler.handleResult(
+            result: result,
+            responseType: CollaboratorListResponseDTO.self,
+            errorType: AddMemberError.self
+        )
+
+        return responseDTO.content.map { $0.toDomain }
+    }
+
     public func delegateHost(capsuleId: Int, targetUserId: Int) async throws {
         let result = await provider.request(.delegateHost(capsuleId: capsuleId, targetUserId: targetUserId))
         try ResultHandler.handleResult(result: result, errorType: AddMemberError.self)

--- a/Projects/Data/TicketData/Sources/ResponseDTO/CollaboratorResponseDTO.swift
+++ b/Projects/Data/TicketData/Sources/ResponseDTO/CollaboratorResponseDTO.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+import BaseDomain
 import TicketDomain
 
 struct CollaboratorListResponseDTO: Decodable {
@@ -23,7 +24,7 @@ struct CollaboratorResponseDTO: Decodable {
             userId: userId,
             nickname: nickname,
             profileImageUrl: profileImageUrl,
-            role: CollaboratorRole(rawValue: contributorRole) ?? .contributor,
+            role: TimeCapsuleRole(rawValue: contributorRole) ?? .contributor,
             isMe: isMe
         )
     }

--- a/Projects/Data/TicketData/Sources/ResponseDTO/TicketDetailResponseDTO.swift
+++ b/Projects/Data/TicketData/Sources/ResponseDTO/TicketDetailResponseDTO.swift
@@ -24,7 +24,7 @@ struct TicketDetailResponseDTO: Decodable {
             openedAt: openedAt.flatMap { DateFormatter.serverDateTime.date(from: $0) },
             mainImageUrl: mainImageUrl,
             timeCapsuleStatus: TimeCapsuleStatus(rawValue: timeCapsuleStatus) ?? .beforeBuried,
-            userRole: CollaboratorRole(rawValue: userRole) ?? .contributor,
+            userRole: TimeCapsuleRole(rawValue: userRole) ?? .contributor,
             myContentCount: myContentCount,
             myImageCount: myImageCount
         )

--- a/Projects/Data/TicketData/Sources/TargetType/AddMemberTargetType.swift
+++ b/Projects/Data/TicketData/Sources/TargetType/AddMemberTargetType.swift
@@ -6,6 +6,7 @@ import BaseData
 public enum AddMemberTargetType {
     case inviteToTimeCapsule(capsuleId: Int)
     case fetchCollaborators(capsuleId: Int)
+    case searchCollaborators(capsuleId: Int, nickname: String)
     case delegateHost(capsuleId: Int, targetUserId: Int)
     case kickContributor(capsuleId: Int, targetUserId: Int)
 }
@@ -17,6 +18,8 @@ extension AddMemberTargetType: BaseTargetType {
             return "/time-capsules/\(capsuleId)/invite"
         case .fetchCollaborators(let capsuleId):
             return "/time-capsules/\(capsuleId)/collaborators"
+        case .searchCollaborators(let capsuleId, _):
+            return "/time-capsules/\(capsuleId)/collaborators/search"
         case .delegateHost(let capsuleId, let targetUserId):
             return "/time-capsules/\(capsuleId)/delegation/\(targetUserId)"
         case .kickContributor(let capsuleId, let targetUserId):
@@ -28,7 +31,7 @@ extension AddMemberTargetType: BaseTargetType {
         switch self {
         case .inviteToTimeCapsule:
             return .post
-        case .fetchCollaborators:
+        case .fetchCollaborators, .searchCollaborators:
             return .get
         case .delegateHost:
             return .put
@@ -39,6 +42,11 @@ extension AddMemberTargetType: BaseTargetType {
 
     public var task: Moya.Task {
         switch self {
+        case .searchCollaborators(_, let nickname):
+            return .requestParameters(
+                parameters: ["nickname": nickname],
+                encoding: URLEncoding.queryString
+            )
         case .inviteToTimeCapsule, .fetchCollaborators, .delegateHost, .kickContributor:
             return .requestPlain
         }
@@ -50,7 +58,7 @@ extension AddMemberTargetType: BaseTargetType {
 
     public var isNeededAccessToken: Bool {
         switch self {
-        case .inviteToTimeCapsule, .fetchCollaborators, .delegateHost, .kickContributor:
+        case .inviteToTimeCapsule, .fetchCollaborators, .searchCollaborators, .delegateHost, .kickContributor:
             return true
         }
     }

--- a/Projects/Domain/TicketDomain/Sources/Entity/CollaboratorEntity.swift
+++ b/Projects/Domain/TicketDomain/Sources/Entity/CollaboratorEntity.swift
@@ -1,22 +1,19 @@
 import Foundation
 
-public enum CollaboratorRole: String {
-    case host = "HOST"
-    case contributor = "CONTRIBUTOR"
-}
+import BaseDomain
 
 public struct CollaboratorEntity {
     public let userId: Int
     public let nickname: String
     public let profileImageUrl: String?
-    public let role: CollaboratorRole
+    public let role: TimeCapsuleRole
     public let isMe: Bool
 
     public init(
         userId: Int,
         nickname: String,
         profileImageUrl: String?,
-        role: CollaboratorRole,
+        role: TimeCapsuleRole,
         isMe: Bool
     ) {
         self.userId = userId

--- a/Projects/Domain/TicketDomain/Sources/Entity/TicketDetailEntity.swift
+++ b/Projects/Domain/TicketDomain/Sources/Entity/TicketDetailEntity.swift
@@ -10,7 +10,7 @@ public struct TicketDetailEntity {
     public let openedAt: Date?
     public let mainImageUrl: String?
     public let timeCapsuleStatus: TimeCapsuleStatus
-    public let userRole: CollaboratorRole
+    public let userRole: TimeCapsuleRole
     public let myContentCount: Int
     public let myImageCount: Int
 
@@ -22,7 +22,7 @@ public struct TicketDetailEntity {
         openedAt: Date?,
         mainImageUrl: String?,
         timeCapsuleStatus: TimeCapsuleStatus,
-        userRole: CollaboratorRole,
+        userRole: TimeCapsuleRole,
         myContentCount: Int,
         myImageCount: Int
     ) {

--- a/Projects/Domain/TicketDomain/Sources/Repository/AddMemberRepository.swift
+++ b/Projects/Domain/TicketDomain/Sources/Repository/AddMemberRepository.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol AddMemberRepository {
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
     func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity]
+    func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity]
     func delegateHost(capsuleId: Int, targetUserId: Int) async throws
     func kickContributor(capsuleId: Int, targetUserId: Int) async throws
 }

--- a/Projects/Domain/TicketDomain/Sources/UseCase/AddMemberUseCase.swift
+++ b/Projects/Domain/TicketDomain/Sources/UseCase/AddMemberUseCase.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol AddMemberUseCase {
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
     func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity]
+    func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity]
     func delegateHost(capsuleId: Int, targetUserId: Int) async throws
     func kickContributor(capsuleId: Int, targetUserId: Int) async throws
 }
@@ -20,6 +21,10 @@ public final class DefaultAddMemberUseCase: AddMemberUseCase {
 
     public func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity] {
         return try await addMemberRepository.fetchCollaborators(capsuleId: capsuleId)
+    }
+
+    public func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity] {
+        return try await addMemberRepository.searchCollaborators(capsuleId: capsuleId, nickname: nickname)
     }
 
     public func delegateHost(capsuleId: Int, targetUserId: Int) async throws {

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
@@ -12,6 +12,8 @@ import RxSwift
 import RxCocoa
 
 import DesignSystem
+
+import BaseDomain
 import TicketDomain
 
 public final class AddMemberViewController: UIViewController {

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
@@ -146,17 +146,24 @@ extension AddMemberViewController {
     private func bindViewModel() {
         let input = AddMemberViewModel.Input(
             rxViewDidLoad: rxViewDidLoad,
+            searchText: searchTextField.rx.text.orEmpty.asObservable(),
             didTapCopyInviteCode: didTapCopyInviteCode,
             didConfirmDelegateHost: didConfirmDelegateHost,
             didConfirmKickContributor: didConfirmKickContributor
         )
         let output = viewModel.transform(input)
 
+        output.isCurrentUserHost
+            .withUnretained(self)
+            .subscribe(onNext: { (self, isHost) in
+                self.isCurrentUserHost = isHost
+            })
+            .disposed(by: disposeBag)
+
         output.memberList
             .withUnretained(self)
             .do(onNext: { (self, list) in
                 self.memberCountLabel.text = "\(list.count)"
-                self.isCurrentUserHost = list.first(where: { $0.isMe })?.role == .host
             })
             .map { $0.1 }
             .bind(to: collectionView.rx.items(

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
@@ -17,6 +17,7 @@ public final class AddMemberViewModel {
 
     private let capsuleId: Int
     private let addMemberUseCase: AddMemberUseCase
+    private var cachedMemberList: [CollaboratorEntity] = []
 
     public init(
         capsuleId: Int,
@@ -28,6 +29,7 @@ public final class AddMemberViewModel {
 
     struct Input {
         let rxViewDidLoad: PublishRelay<Void>
+        let searchText: Observable<String>
         let didTapCopyInviteCode: PublishRelay<Void>
         let didConfirmDelegateHost: PublishRelay<Int>
         let didConfirmKickContributor: PublishRelay<Int>
@@ -35,6 +37,7 @@ public final class AddMemberViewModel {
 
     struct Output {
         let memberList: PublishRelay<[CollaboratorEntity]>
+        let isCurrentUserHost: BehaviorRelay<Bool>
         let inviteCode: PublishRelay<String>
         let errorToast: PublishRelay<String>
         let delegateHostSuccess: PublishRelay<Void>
@@ -43,6 +46,7 @@ public final class AddMemberViewModel {
 
     func transform(_ input: Input) -> Output {
         let memberList: PublishRelay<[CollaboratorEntity]> = .init()
+        let isCurrentUserHost: BehaviorRelay<Bool> = .init(value: false)
         let inviteCode: PublishRelay<String> = .init()
         let errorToast: PublishRelay<String> = .init()
         let delegateHostSuccess: PublishRelay<Void> = .init()
@@ -58,11 +62,43 @@ public final class AddMemberViewModel {
                             capsuleId: self.capsuleId
                         )
                         await MainActor.run {
+                            self.cachedMemberList = collaborators
+                            isCurrentUserHost.accept(collaborators.first(where: { $0.isMe })?.role == .host)
                             memberList.accept(collaborators)
                         }
                     } catch {
                         await MainActor.run {
                             errorToast.accept("멤버 목록을 불러올 수 없습니다")
+                        }
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
+        input.searchText
+            .skip(1)
+            .distinctUntilChanged()
+            .debounce(.milliseconds(600), scheduler: MainScheduler.instance)
+            .withUnretained(self)
+            .subscribe(onNext: { (self, text) in
+                let keyword = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !keyword.isEmpty else {
+                    memberList.accept(self.cachedMemberList)
+                    return
+                }
+                Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        let results = try await self.addMemberUseCase.searchCollaborators(
+                            capsuleId: self.capsuleId,
+                            nickname: keyword
+                        )
+                        await MainActor.run {
+                            memberList.accept(results)
+                        }
+                    } catch {
+                        await MainActor.run {
+                            errorToast.accept("멤버 검색에 실패했습니다")
                         }
                     }
                 }
@@ -104,6 +140,8 @@ public final class AddMemberViewModel {
                             capsuleId: self.capsuleId
                         )
                         await MainActor.run {
+                            self.cachedMemberList = updated
+                            isCurrentUserHost.accept(updated.first(where: { $0.isMe })?.role == .host)
                             delegateHostSuccess.accept(())
                             memberList.accept(updated)
                         }
@@ -130,6 +168,8 @@ public final class AddMemberViewModel {
                             capsuleId: self.capsuleId
                         )
                         await MainActor.run {
+                            self.cachedMemberList = updated
+                            isCurrentUserHost.accept(updated.first(where: { $0.isMe })?.role == .host)
                             kickContributorSuccess.accept(())
                             memberList.accept(updated)
                         }
@@ -144,6 +184,7 @@ public final class AddMemberViewModel {
 
         return .init(
             memberList: memberList,
+            isCurrentUserHost: isCurrentUserHost,
             inviteCode: inviteCode,
             errorToast: errorToast,
             delegateHostSuccess: delegateHostSuccess,

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
+import BaseDomain
 import TicketDomain
 
 public final class AddMemberViewModel {


### PR DESCRIPTION
## 작업 내용
멤버(AddMember) 화면의 검색바에 협력자 검색을 연동했습니다. 검색어 입력 시 디바운스로 자동 검색됩니다.
추가로 동일 의미로 중복 정의돼 있던 역할 enum `CollaboratorRole` 을 `TimeCapsuleRole` 로 통일했습니다.

## 변경 사항

### 1. 멤버 협력자 검색 (Feature)
- `GET /time-capsules/{capsuleId}/collaborators/search?nickname=` 연동
  - 응답의 페이지네이션 값(`totalPages` / `totalElements` / `number` / `last`)은 무시 (기존 `CollaboratorListResponseDTO` 재사용)
- 검색어 입력 → `debounce(300ms)` + `distinctUntilChanged` → 자동 검색
- 검색어가 비면 캐시된 전체 멤버 목록으로 복원
- 검색 결과에 본인이 포함되지 않아도 방장 관리(⋯) 버튼이 유지되도록 `isCurrentUserHost` output 분리
- 신규 파일 없이 기존 AddMember 체인 확장 (TargetType / Repository / UseCase / ViewModel / ViewController)

### 2. 역할 enum 통일 (Refactor)
- `CollaboratorRole`(TicketDomain) 삭제 → 공유 모듈 `BaseDomain` 의 `TimeCapsuleRole` 로 일원화
- 두 enum 의 케이스/raw value 동일 (`host = "HOST"`, `contributor = "CONTRIBUTOR"`)
- `CollaboratorEntity.role`, `TicketDetailEntity.userRole` 및 관련 DTO 매핑을 `TimeCapsuleRole` 로 변경

## 리뷰 포인트
- "멤버 N" 카운트는 현재 표시 중인 목록 기준입니다 (검색 중에는 일치 개수). 항상 전체 멤버 수로 노출되길 원하면 알려주세요.
- 디바운스는 300ms 입니다. 값 조정이나 `throttle` 전환이 필요하면 의견 주세요.
- 디자인: [Figma - 멤버 화면](https://www.figma.com/design/KepM12kWDI4JcoYyXAyVZN/임시-메실?node-id=906-16532)