### PR TITLE
Feature: 공동 작업자 목록 조회 API 페이지네이션 도입

### DIFF
--- a/Projects/Data/BaseData/Sources/Provider/DefaultProvider.swift
+++ b/Projects/Data/BaseData/Sources/Provider/DefaultProvider.swift
@@ -24,7 +24,7 @@ public final class DefaultProvider<T: TargetType>: MoyaProvider<T> {
                 done(.failure(MoyaError.underlying(error, nil)))
             }
         }
-        
+
         let interceptor: RequestInterceptor = AuthorizationInterceptor.shared
         let authorizationPlugin: PluginType = AuthorizationPlugin.shared
         let loggerPlugin: MoyaLoggerPlugin = .init()

--- a/Projects/Data/TicketData/Sources/Repository/DefaultAddMemberRepository.swift
+++ b/Projects/Data/TicketData/Sources/Repository/DefaultAddMemberRepository.swift
@@ -23,8 +23,12 @@ public final class DefaultAddMemberRepository: AddMemberRepository {
         return responseDTO.code
     }
 
-    public func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity] {
-        let result = await provider.request(.fetchCollaborators(capsuleId: capsuleId))
+    public func fetchCollaborators(
+        capsuleId: Int,
+        page: Int,
+        size: Int
+    ) async throws -> CollaboratorPageEntity {
+        let result = await provider.request(.fetchCollaborators(capsuleId: capsuleId, page: page, size: size))
 
         let responseDTO = try ResultHandler.handleResult(
             result: result,
@@ -32,7 +36,7 @@ public final class DefaultAddMemberRepository: AddMemberRepository {
             errorType: AddMemberError.self
         )
 
-        return responseDTO.content.map { $0.toDomain }
+        return responseDTO.toDomain
     }
 
     public func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity] {

--- a/Projects/Data/TicketData/Sources/Repository/DefaultCapsuleContentRepository.swift
+++ b/Projects/Data/TicketData/Sources/Repository/DefaultCapsuleContentRepository.swift
@@ -19,13 +19,13 @@ public final class DefaultCapsuleContentRepository: CapsuleContentRepository {
     public func fetchCapsuleContents(capsuleId: Int) async throws -> [CapsuleContentGroupEntity] {
         let result = await provider.request(.fetchCapsuleContents(capsuleId: capsuleId))
 
-        let responseDTOs = try ResultHandler.handleResult(
+        let responseDTO = try ResultHandler.handleResult(
             result: result,
-            responseType: [CapsuleContentGroupResponseDTO].self,
+            responseType: CapsuleContentListResponseDTO.self,
             errorType: CapsuleContentError.self
         )
 
-        return responseDTOs.map { $0.toDomain }
+        return responseDTO.content.map { $0.toDomain }
     }
 
     public func fetchCurrentUserId() -> Int? {

--- a/Projects/Data/TicketData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
+++ b/Projects/Data/TicketData/Sources/ResponseDTO/CapsuleContentResponseDTO.swift
@@ -2,6 +2,14 @@ import Foundation
 
 import TicketDomain
 
+struct CapsuleContentListResponseDTO: Decodable {
+    let content: [CapsuleContentGroupResponseDTO]
+    let last: Bool?
+    let number: Int?
+    let totalElements: Int?
+    let totalPages: Int?
+}
+
 struct CapsuleContentGroupResponseDTO: Decodable {
     let userId: Int
     let nickname: String

--- a/Projects/Data/TicketData/Sources/ResponseDTO/CollaboratorResponseDTO.swift
+++ b/Projects/Data/TicketData/Sources/ResponseDTO/CollaboratorResponseDTO.swift
@@ -9,6 +9,15 @@ struct CollaboratorListResponseDTO: Decodable {
     let number: Int?
     let totalElements: Int?
     let totalPages: Int?
+
+    var toDomain: CollaboratorPageEntity {
+        return .init(
+            collaborators: content.map { $0.toDomain },
+            currentPage: number ?? 0,
+            isLast: last ?? true,
+            totalElements: totalElements ?? content.count
+        )
+    }
 }
 
 struct CollaboratorResponseDTO: Decodable {

--- a/Projects/Data/TicketData/Sources/TargetType/AddMemberTargetType.swift
+++ b/Projects/Data/TicketData/Sources/TargetType/AddMemberTargetType.swift
@@ -5,7 +5,7 @@ import BaseData
 
 public enum AddMemberTargetType {
     case inviteToTimeCapsule(capsuleId: Int)
-    case fetchCollaborators(capsuleId: Int)
+    case fetchCollaborators(capsuleId: Int, page: Int, size: Int)
     case searchCollaborators(capsuleId: Int, nickname: String)
     case delegateHost(capsuleId: Int, targetUserId: Int)
     case kickContributor(capsuleId: Int, targetUserId: Int)
@@ -16,7 +16,7 @@ extension AddMemberTargetType: BaseTargetType {
         switch self {
         case .inviteToTimeCapsule(let capsuleId):
             return "/time-capsules/\(capsuleId)/invite"
-        case .fetchCollaborators(let capsuleId):
+        case .fetchCollaborators(let capsuleId, _, _):
             return "/time-capsules/\(capsuleId)/collaborators"
         case .searchCollaborators(let capsuleId, _):
             return "/time-capsules/\(capsuleId)/collaborators/search"
@@ -42,12 +42,17 @@ extension AddMemberTargetType: BaseTargetType {
 
     public var task: Moya.Task {
         switch self {
+        case .fetchCollaborators(_, let page, let size):
+            return .requestParameters(
+                parameters: ["page": page, "size": size],
+                encoding: URLEncoding.queryString
+            )
         case .searchCollaborators(_, let nickname):
             return .requestParameters(
                 parameters: ["nickname": nickname],
                 encoding: URLEncoding.queryString
             )
-        case .inviteToTimeCapsule, .fetchCollaborators, .delegateHost, .kickContributor:
+        case .inviteToTimeCapsule, .delegateHost, .kickContributor:
             return .requestPlain
         }
     }

--- a/Projects/Domain/TicketDomain/Sources/Entity/CollaboratorPageEntity.swift
+++ b/Projects/Domain/TicketDomain/Sources/Entity/CollaboratorPageEntity.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct CollaboratorPageEntity {
+    public let collaborators: [CollaboratorEntity]
+    public let currentPage: Int
+    public let isLast: Bool
+    public let totalElements: Int
+
+    public init(
+        collaborators: [CollaboratorEntity],
+        currentPage: Int,
+        isLast: Bool,
+        totalElements: Int
+    ) {
+        self.collaborators = collaborators
+        self.currentPage = currentPage
+        self.isLast = isLast
+        self.totalElements = totalElements
+    }
+}

--- a/Projects/Domain/TicketDomain/Sources/Repository/AddMemberRepository.swift
+++ b/Projects/Domain/TicketDomain/Sources/Repository/AddMemberRepository.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol AddMemberRepository {
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
-    func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity]
+    func fetchCollaborators(capsuleId: Int, page: Int, size: Int) async throws -> CollaboratorPageEntity
     func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity]
     func delegateHost(capsuleId: Int, targetUserId: Int) async throws
     func kickContributor(capsuleId: Int, targetUserId: Int) async throws

--- a/Projects/Domain/TicketDomain/Sources/UseCase/AddMemberUseCase.swift
+++ b/Projects/Domain/TicketDomain/Sources/UseCase/AddMemberUseCase.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol AddMemberUseCase {
     func inviteToTimeCapsule(capsuleId: Int) async throws -> String
-    func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity]
+    func fetchCollaborators(capsuleId: Int, page: Int, size: Int) async throws -> CollaboratorPageEntity
     func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity]
     func delegateHost(capsuleId: Int, targetUserId: Int) async throws
     func kickContributor(capsuleId: Int, targetUserId: Int) async throws
@@ -19,8 +19,16 @@ public final class DefaultAddMemberUseCase: AddMemberUseCase {
         return try await addMemberRepository.inviteToTimeCapsule(capsuleId: capsuleId)
     }
 
-    public func fetchCollaborators(capsuleId: Int) async throws -> [CollaboratorEntity] {
-        return try await addMemberRepository.fetchCollaborators(capsuleId: capsuleId)
+    public func fetchCollaborators(
+        capsuleId: Int,
+        page: Int,
+        size: Int
+    ) async throws -> CollaboratorPageEntity {
+        return try await addMemberRepository.fetchCollaborators(
+            capsuleId: capsuleId,
+            page: page,
+            size: size
+        )
     }
 
     public func searchCollaborators(capsuleId: Int, nickname: String) async throws -> [CollaboratorEntity] {

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
@@ -149,6 +149,7 @@ extension AddMemberViewController {
         let input = AddMemberViewModel.Input(
             rxViewDidLoad: rxViewDidLoad,
             searchText: searchTextField.rx.text.orEmpty.asObservable(),
+            prefetchRows: collectionView.rx.prefetchItems.asObservable(),
             didTapCopyInviteCode: didTapCopyInviteCode,
             didConfirmDelegateHost: didConfirmDelegateHost,
             didConfirmKickContributor: didConfirmKickContributor

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
@@ -20,6 +20,12 @@ public final class AddMemberViewModel {
     private let addMemberUseCase: AddMemberUseCase
     private var cachedMemberList: [CollaboratorEntity] = []
 
+    private let pageSize: Int = 20
+    private var currentPage: Int = 0
+    private var isLast: Bool = false
+    private var isLoading: Bool = false
+    private var isSearching: Bool = false
+
     public init(
         capsuleId: Int,
         addMemberUseCase: AddMemberUseCase
@@ -31,6 +37,7 @@ public final class AddMemberViewModel {
     struct Input {
         let rxViewDidLoad: PublishRelay<Void>
         let searchText: Observable<String>
+        let prefetchRows: Observable<[IndexPath]>
         let didTapCopyInviteCode: PublishRelay<Void>
         let didConfirmDelegateHost: PublishRelay<Int>
         let didConfirmKickContributor: PublishRelay<Int>
@@ -53,25 +60,58 @@ public final class AddMemberViewModel {
         let delegateHostSuccess: PublishRelay<Void> = .init()
         let kickContributorSuccess: PublishRelay<Void> = .init()
 
+        let loadMembers: (Bool) -> Void = { [weak self] reset in
+            guard let self else { return }
+            guard !self.isLoading else { return }
+            if reset {
+                self.currentPage = 0
+                self.isLast = false
+            }
+            guard !self.isLast else { return }
+            self.isLoading = true
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    let page = try await self.addMemberUseCase.fetchCollaborators(
+                        capsuleId: self.capsuleId,
+                        page: self.currentPage,
+                        size: self.pageSize
+                    )
+                    await MainActor.run {
+                        if reset {
+                            self.cachedMemberList = page.collaborators
+                        } else {
+                            self.cachedMemberList.append(contentsOf: page.collaborators)
+                        }
+                        self.isLast = page.isLast
+                        self.currentPage += 1
+                        self.isLoading = false
+                        isCurrentUserHost.accept(self.cachedMemberList.first(where: { $0.isMe })?.role == .host)
+                        memberList.accept(self.cachedMemberList)
+                    }
+                } catch {
+                    await MainActor.run {
+                        self.isLoading = false
+                        errorToast.accept("멤버 목록을 불러올 수 없습니다")
+                    }
+                }
+            }
+        }
+
         input.rxViewDidLoad
             .withUnretained(self)
-            .subscribe(onNext: { (self, _) in
-                Task { [weak self] in
-                    guard let self else { return }
-                    do {
-                        let collaborators = try await self.addMemberUseCase.fetchCollaborators(
-                            capsuleId: self.capsuleId
-                        )
-                        await MainActor.run {
-                            self.cachedMemberList = collaborators
-                            isCurrentUserHost.accept(collaborators.first(where: { $0.isMe })?.role == .host)
-                            memberList.accept(collaborators)
-                        }
-                    } catch {
-                        await MainActor.run {
-                            errorToast.accept("멤버 목록을 불러올 수 없습니다")
-                        }
-                    }
+            .subscribe(onNext: { (_, _) in
+                loadMembers(true)
+            })
+            .disposed(by: disposeBag)
+
+        input.prefetchRows
+            .withUnretained(self)
+            .subscribe(onNext: { (self, indexPaths) in
+                guard !self.isSearching, !self.isLoading, !self.isLast else { return }
+                let threshold = self.cachedMemberList.count - 2
+                if indexPaths.contains(where: { $0.item >= threshold }) {
+                    loadMembers(false)
                 }
             })
             .disposed(by: disposeBag)
@@ -84,9 +124,11 @@ public final class AddMemberViewModel {
             .subscribe(onNext: { (self, text) in
                 let keyword = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !keyword.isEmpty else {
+                    self.isSearching = false
                     memberList.accept(self.cachedMemberList)
                     return
                 }
+                self.isSearching = true
                 Task { [weak self] in
                     guard let self else { return }
                     do {
@@ -137,14 +179,9 @@ public final class AddMemberViewModel {
                             capsuleId: self.capsuleId,
                             targetUserId: targetUserId
                         )
-                        let updated = try await self.addMemberUseCase.fetchCollaborators(
-                            capsuleId: self.capsuleId
-                        )
                         await MainActor.run {
-                            self.cachedMemberList = updated
-                            isCurrentUserHost.accept(updated.first(where: { $0.isMe })?.role == .host)
                             delegateHostSuccess.accept(())
-                            memberList.accept(updated)
+                            loadMembers(true)
                         }
                     } catch {
                         await MainActor.run {
@@ -165,14 +202,9 @@ public final class AddMemberViewModel {
                             capsuleId: self.capsuleId,
                             targetUserId: targetUserId
                         )
-                        let updated = try await self.addMemberUseCase.fetchCollaborators(
-                            capsuleId: self.capsuleId
-                        )
                         await MainActor.run {
-                            self.cachedMemberList = updated
-                            isCurrentUserHost.accept(updated.first(where: { $0.isMe })?.role == .host)
                             kickContributorSuccess.accept(())
-                            memberList.accept(updated)
+                            loadMembers(true)
                         }
                     } catch {
                         await MainActor.run {

--- a/Projects/Presentation/TicketPresentation/Sources/TicketDetail/ViewModel/TicketDetailViewModel.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/TicketDetail/ViewModel/TicketDetailViewModel.swift
@@ -138,9 +138,9 @@ extension TicketDetailViewModel {
         Task { [weak self] in
             guard let self else { return }
             do {
-                let list = try await self.addMemberUseCase.fetchCollaborators(capsuleId: self.capsuleId)
+                let page = try await self.addMemberUseCase.fetchCollaborators(capsuleId: self.capsuleId, page: 0, size: 10)
                 await MainActor.run {
-                    self.collaborators.accept(list)
+                    self.collaborators.accept(page.collaborators)
                 }
             } catch {
                 await MainActor.run {


### PR DESCRIPTION
## 변경 사항

### `GET /time-capsules/{capsuleId}/collaborators` 페이지네이션
- TargetType `fetchCollaborators` 에 `page`/`size` 쿼리 파라미터 추가
- 페이지네이션 결과를 담는 `CollaboratorPageEntity` 추가 (`collaborators` / `currentPage` / `isLast` / `totalElements`)
- Repository / UseCase 시그니처를 `fetchCollaborators(capsuleId:page:size:) -> CollaboratorPageEntity` 로 변경
- `AddMemberViewModel`: 페이지 상태 관리 + `prefetchRows` 입력 기반 무한 스크롤(누적 로딩) 구현, 검색 중에는 prefetch 무시, 방장 위임/멤버 추방 시 첫 페이지부터 새로고침
- `AddMemberViewController`: `collectionView.rx.prefetchItems` 를 ViewModel 입력으로 연결
- `TicketDetailViewModel`: 변경된 시그니처에 맞춰 첫 페이지 조회로 호출 변경

### `GET /api/time-capsule-content/{timeCapsuleId}/contents` 응답 형식 수정
- 응답을 페이지네이션 래퍼 형식으로 받도록 `CapsuleContentListResponseDTO` 추가
- Repository 파싱 타입을 배열 → 래퍼(`.content` 매핑)로 변경 (실 사용처 없어 형식만 반영)

## 테스트 방법

- [ ] 멤버 화면 진입 시 공동 작업자 목록이 정상 표시되는지 확인
- [ ] 목록을 아래로 스크롤하면 다음 페이지가 prefetch 로 이어서 로드되는지 확인
- [ ] 검색어 입력 시 검색 결과가 표시되고, 검색 중에는 페이지네이션이 동작하지 않는지 확인
- [ ] 검색어를 비우면 기존 누적 목록으로 복귀하는지 확인
- [ ] 방장 위임 / 멤버 추방 후 목록이 첫 페이지부터 갱신되는지 확인
- [ ] 티켓 상세 화면의 멤버 미리보기가 정상 표시되는지 확인