### PR TITLE
Feature: Home 상단 유저 프로필 이미지를 API 값으로 바인딩

### DIFF
--- a/Projects/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
+++ b/Projects/Feature/HomeFeature/Sources/Coordinator/HomeCoordinator.swift
@@ -28,6 +28,7 @@ public final class HomeCoordinator {
     private let dependency: Dependency
 
     private var hostHomeViewModel: HomeViewModel?
+    private var homeTabmanViewModel: HomeTabmanViewModel?
 
     public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
@@ -36,6 +37,10 @@ public final class HomeCoordinator {
 
     public func refreshHome() {
         hostHomeViewModel?.refresh()
+    }
+
+    public func refreshProfile() {
+        homeTabmanViewModel?.refresh()
     }
 
     public func start() {
@@ -52,8 +57,10 @@ public final class HomeCoordinator {
         let hostHomeViewController = homeDIContainer.makeHomeViewController(with: hostHomeViewModel)
         let contributorHomeViewController = homeDIContainer.makeHomeViewController(action: homeAction, role: .contributor)
 
+        let homeTabmanViewModel = homeDIContainer.makeHomeTabmanViewModel(action: tabmanAction)
+        self.homeTabmanViewModel = homeTabmanViewModel
         let homeTabManViewController = homeDIContainer.makeHomeTabmanViewController(
-            action: tabmanAction,
+            with: homeTabmanViewModel,
             viewControllers: [
                 hostHomeViewController,
                 contributorHomeViewController

--- a/Projects/Feature/HomeFeature/Sources/DIContainer/HomeDIContainer.swift
+++ b/Projects/Feature/HomeFeature/Sources/DIContainer/HomeDIContainer.swift
@@ -16,8 +16,18 @@ import HomeData
 import HomeDomain
 
 public final class HomeDIContainer {
-    private func makeHomeTabmanViewModel(action: HomeTabmanViewModel.Action) -> HomeTabmanViewModel {
-        return HomeTabmanViewModel(action: action)
+    private func makeUserUseCase() -> UserUseCase {
+        let provider = DefaultProvider<UserTargetType>()
+        let repository = DefaultUserRepository(
+            provider: provider,
+            userDefaultStorage: DefaultUserDefaultStorage(),
+            keyChainStorage: DefaultKeyChainStorage()
+        )
+        return DefaultUserUseCase(userRepository: repository)
+    }
+
+    func makeHomeTabmanViewModel(action: HomeTabmanViewModel.Action) -> HomeTabmanViewModel {
+        return HomeTabmanViewModel(action: action, userUseCase: makeUserUseCase())
     }
 
     func makeHomeTabmanViewController(
@@ -27,6 +37,16 @@ public final class HomeDIContainer {
         return HomeTabmanViewController(
             viewControllers: viewControllers,
             with: makeHomeTabmanViewModel(action: action)
+        )
+    }
+
+    func makeHomeTabmanViewController(
+        with viewModel: HomeTabmanViewModel,
+        viewControllers: [UIViewController]
+    ) -> HomeTabmanViewController {
+        return HomeTabmanViewController(
+            viewControllers: viewControllers,
+            with: viewModel
         )
     }
 

--- a/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
+++ b/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
@@ -54,6 +54,9 @@ public final class MainCoordinator {
             didLogout: { [weak self] in
                 self?.profileCoordinator = nil
                 self?.dependency.didRequestLogout()
+            },
+            didEditProfile: { [weak self] in
+                self?.homeCoordinator?.refreshProfile()
             }
         )
         let coordinator = ProfileCoordinator(with: navigationController, dependency: profileDependency)

--- a/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
+++ b/Projects/Feature/ProfileFeature/Sources/Coordinator/ProfileCoordinator.swift
@@ -14,10 +14,16 @@ public final class ProfileCoordinator {
     public struct Dependency {
         public let moveToBack: () -> Void
         public let didLogout: () -> Void
+        public let didEditProfile: () -> Void
 
-        public init(moveToBack: @escaping () -> Void, didLogout: @escaping () -> Void) {
+        public init(
+            moveToBack: @escaping () -> Void,
+            didLogout: @escaping () -> Void,
+            didEditProfile: @escaping () -> Void
+        ) {
             self.moveToBack = moveToBack
             self.didLogout = didLogout
+            self.didEditProfile = didEditProfile
         }
     }
 
@@ -52,6 +58,7 @@ public final class ProfileCoordinator {
             moveToBack: popViewController,
             didEditProfile: { [weak self] in
                 self?.profileViewModel?.refresh()
+                self?.dependency.didEditProfile()
             }
         )
         let editProfileViewController = profileDIContainer.makeEditProfileViewController(

--- a/Projects/Presentation/HomePresentation/Sources/Tabman/Controller/HomeTabmanViewController.swift
+++ b/Projects/Presentation/HomePresentation/Sources/Tabman/Controller/HomeTabmanViewController.swift
@@ -12,6 +12,7 @@ import RxSwift
 import RxCocoa
 import Tabman
 import Pageboy
+import Kingfisher
 
 import DesignSystem
 
@@ -32,7 +33,8 @@ enum HomeTabMenu: Int, CaseIterable {
 public final class HomeTabmanViewController: TabmanViewController {
     private let disposeBag: DisposeBag = DisposeBag()
     private let viewModel: HomeTabmanViewModel
-    
+    private let rxViewDidLoad: PublishRelay<Void> = .init()
+
     private var viewControllers: [UIViewController] = []
     
     private let tabManBackgroundView: UIView = {
@@ -52,10 +54,12 @@ public final class HomeTabmanViewController: TabmanViewController {
     private let userProfileButton: UIButton = {
         let button = UIButton()
         button.layer.cornerRadius = 16
+        button.clipsToBounds = true
         button.setImage(
             DesignSystemAsset.ImageAssets.userDefaultProfileImage.image,
             for: .normal
         )
+        button.imageView?.contentMode = .scaleAspectFill
         return button
     }()
     
@@ -188,6 +192,8 @@ public final class HomeTabmanViewController: TabmanViewController {
         )
 
         self.disableClipping(in: homeTabManBar)
+
+        self.rxViewDidLoad.accept(())
     }
 }
 
@@ -201,11 +207,19 @@ extension HomeTabmanViewController {
 extension HomeTabmanViewController {
     private func bindViewModel() {
         let input = HomeTabmanViewModel.Input(
+            rxViewDidLoad: rxViewDidLoad,
             createTicketButtonDidTap: createNewTicketButton.rx.tap,
             profileButtonDidTap: userProfileButton.rx.tap,
             enterTicketButtonDidTap: enterTickButton.rx.tap
         )
-        let _ = viewModel.transform(input)
+        let output = viewModel.transform(input)
+
+        output.profileImageUrl
+            .drive(with: self) { (self, urlString) in
+                guard let urlString, let url = URL(string: urlString) else { return }
+                self.userProfileButton.kf.setImage(with: url, for: .normal)
+            }
+            .disposed(by: disposeBag)
     }
     
     private func bindButtons() {

--- a/Projects/Presentation/HomePresentation/Sources/Tabman/ViewModel/HomeTabmanViewModel.swift
+++ b/Projects/Presentation/HomePresentation/Sources/Tabman/ViewModel/HomeTabmanViewModel.swift
@@ -9,8 +9,11 @@
 import RxSwift
 import RxCocoa
 
+import BaseDomain
+
 public final class HomeTabmanViewModel {
     private let disposeBag: DisposeBag = DisposeBag()
+    private let userUseCase: UserUseCase
 
     public struct Action {
         public let moveToCreateTicket: () -> Void
@@ -26,21 +29,47 @@ public final class HomeTabmanViewModel {
 
     public let action: Action
 
-    public init(action: Action) {
+    private let profileImageUrl: PublishRelay<String?> = .init()
+    private let refreshRelay: PublishRelay<Void> = .init()
+
+    public func refresh() {
+        refreshRelay.accept(())
+    }
+
+    public init(action: Action, userUseCase: UserUseCase) {
         self.action = action
+        self.userUseCase = userUseCase
     }
 
     struct Input {
+        let rxViewDidLoad: PublishRelay<Void>
         let createTicketButtonDidTap: ControlEvent<Void>
         let profileButtonDidTap: ControlEvent<Void>
         let enterTicketButtonDidTap: ControlEvent<Void>
     }
 
     struct Output {
-
+        let profileImageUrl: Driver<String?>
     }
 
     func transform(_ input: Input) -> Output {
+        Observable.merge(
+            input.rxViewDidLoad.asObservable(),
+            refreshRelay.asObservable()
+        )
+        .withUnretained(self)
+        .subscribe(onNext: { (self, _) in
+            Task {
+                do {
+                    let user = try await self.userUseCase.fetchUserInfo()
+                    await MainActor.run {
+                        self.profileImageUrl.accept(user.profileImageUrl)
+                    }
+                } catch {}
+            }
+        })
+        .disposed(by: disposeBag)
+
         input.createTicketButtonDidTap
             .withUnretained(self)
             .subscribe(onNext: { (self, _) in
@@ -61,6 +90,7 @@ public final class HomeTabmanViewModel {
                 self.action.moveToEnterTicket()
             })
             .disposed(by: disposeBag)
-        return Output()
+
+        return Output(profileImageUrl: profileImageUrl.asDriver(onErrorJustReturn: nil))
     }
 }


### PR DESCRIPTION
## 개요
Home 상단 바의 프로필 버튼이 기본 이미지로 고정돼 있던 것을, 유저 프로필 API(`GET /users/me`)에서 받아온 실제 프로필 이미지로 표시하도록 바인딩했습니다.

## 배경
- 기존 `HomeTabmanViewController`의 `userProfileButton`은 `userDefaultProfileImage`만 설정하고 실제 프로필 이미지를 로드하지 않았습니다.
- `HomeTabmanViewModel`에는 유저 정보를 조회할 의존성(UserUseCase) 자체가 없었습니다.

## 작업 내용
- **HomeTabmanViewModel**
  - `UserUseCase` 의존성 주입
  - `Input.rxViewDidLoad` 추가 → 진입 시 `fetchUserInfo()` 호출
  - 조회한 `profileImageUrl`을 `Output`(`Driver<String?>`)으로 노출
  - 프로필 이미지 URL은 `.value` 직접 조회가 없고 구독이 방출보다 먼저 일어나므로, 상태 보유가 불필요한 `PublishRelay`로 관리
- **HomeTabmanViewController**
  - `rxViewDidLoad` relay 추가 및 `viewDidLoad`에서 발화
  - `output.profileImageUrl`을 `userProfileButton`에 Kingfisher로 바인딩 (기본 이미지 → 실제 프로필 이미지)
  - 원형 표시를 위해 `clipsToBounds` + `imageView.contentMode = .scaleAspectFill` 설정
- **HomeDIContainer**
  - `makeUserUseCase()` 추가(BaseData `DefaultUserRepository` + UserDefault/KeyChain 스토리지) 후 `HomeTabmanViewModel`에 주입

## 동작
Home 진입 → `GET /users/me` 조회 → 응답 도착 시 상단 프로필 버튼 이미지가 기본 → 실제 프로필 이미지로 갱신 (URL이 비어있거나 유효하지 않으면 기본 이미지 유지)

## 확인 사항
- 전체 앱(`MemorySeal`) 빌드 통과
- 별도 신규 에셋/리소스 추가 없음 (기존 Kingfisher 사용)