### PR TITLE
[Feature] DELETE /auth/logout API 연동

### DIFF
--- a/Projects/Data/SignInData/Sources/Repository/DefaultAuthRepository.swift
+++ b/Projects/Data/SignInData/Sources/Repository/DefaultAuthRepository.swift
@@ -54,9 +54,15 @@ public final class DefaultAuthRepository: AuthRepository {
     }
 
     public func logout() async throws {
-        _ = await authProvider.request(.logout)
+        let result = await authProvider.request(.logout)
+
         _ = keyChainStorage.delete(key: .accessToken)
         _ = keyChainStorage.delete(key: .refreshToken)
         userDefaultStorage.remove(forKey: .userId)
+
+        try ResultHandler.handleResult(
+            result: result,
+            errorType: LogoutError.self
+        )
     }
 }

--- a/Projects/Domain/SignInDomain/Sources/Error/LogoutError.swift
+++ b/Projects/Domain/SignInDomain/Sources/Error/LogoutError.swift
@@ -1,0 +1,34 @@
+//
+//  LogoutError.swift
+//  SignInDomain
+//
+//  Created by 선민재 on 7/31/26.
+//  Copyright © 2026 MemorySeal. All rights reserved.
+//
+
+import Foundation
+
+import BaseDomain
+
+public enum LogoutError: DomainError, LocalizedError {
+    case defaultError
+    case refreshTokenNotFound
+
+    public var errorDescription: String? {
+        switch self {
+        case .defaultError:
+            return "로그아웃에 실패했습니다. 다시 시도해주세요."
+        case .refreshTokenNotFound:
+            return "저장된 리프레시 토큰이 없습니다."
+        }
+    }
+
+    public init(errorResponse: ErrorResponseEntity) {
+        switch errorResponse.error {
+        case "REFRESHTOKEN_NOT_FOUND":
+            self = .refreshTokenNotFound
+        default:
+            self = .defaultError
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

- `LogoutError` 추가 — 404 `REFRESHTOKEN_NOT_FOUND` 응답을 `.refreshTokenNotFound` 로 매핑
- `DefaultAuthRepository.logout()` 에 `ResultHandler` 적용
  - 기존에는 `_ = await authProvider.request(.logout)` 로 응답을 버려서 서버 결과와 무관하게 로컬 토큰만 삭제하고 있었음
  - 로컬 세션 정리(accessToken / refreshToken / userId)를 응답 검증보다 먼저 수행 — 404 응답이어도 클라이언트는 로그아웃 상태가 되어야 하므로

`AuthTargetType.logout` (DELETE `/auth/logout`, `isNeededAccessToken: true`) 은 기존에 정의돼 있어 그대로 사용했고, Authorization 헤더는 `DefaultProvider` 의 `AuthorizationPlugin` 이 주입합니다.

## 테스트 방법

- [x] 설정 → 로그아웃 → 정상 로그아웃 및 로그인 화면 진입 확인
- [x] 로그아웃 요청에 `Authorization: Bearer {accessToken}` 헤더가 실려 나가는지 확인
- [x] 로그아웃 후 앱 재실행 시 자동 로그인되지 않는지 확인 (Keychain 토큰 삭제 확인)
