### PR TITLE
Fix: 스플래시 화면을 LaunchScreen과 동일하게 변경

### DIFF
--- a/Projects/Presentation/SplashPresentation/Sources/Controller/SplashViewController.swift
+++ b/Projects/Presentation/SplashPresentation/Sources/Controller/SplashViewController.swift
@@ -9,22 +9,32 @@
 import UIKit
 import SnapKit
 
+import DesignSystem
+
 public final class SplashViewController: UIViewController {
+    // MARK: - Constant
+    private enum Metric {
+        static let logoLeading: CGFloat = 29
+        static let logoTop: CGFloat = 259
+        static let logoSize: CGFloat = 335
+    }
+
+    private enum Constant {
+        static let backgroundColorHex: String = "#F4F4CC"
+        static let logoImageName: String = "MemorySealLogo"
+    }
+
     private let viewModel: SplashViewModel
 
+    // MARK: - UI
     private let logoImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "MemorySeal_Logo")
+        imageView.image = UIImage(named: Constant.logoImageName)
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
 
-    private let activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .medium)
-        indicator.hidesWhenStopped = true
-        return indicator
-    }()
-
+    // MARK: - Init
     public init(with viewModel: SplashViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -34,6 +44,7 @@ public final class SplashViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Life Cycle
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUpView()
@@ -42,28 +53,22 @@ public final class SplashViewController: UIViewController {
 
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        activityIndicator.startAnimating()
         viewModel.executeAutoSignIn()
     }
 }
 
 private extension SplashViewController {
     func setUpView() {
-        view.backgroundColor = .white
+        view.backgroundColor = UIColor(hex: Constant.backgroundColorHex)
         view.addSubview(logoImageView)
-        view.addSubview(activityIndicator)
     }
 
     func setUpConstraints() {
         logoImageView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.width.equalTo(200)
-            $0.height.equalTo(200)
-        }
-
-        activityIndicator.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(logoImageView.snp.bottom).offset(24)
+            $0.leading.equalToSuperview().offset(Metric.logoLeading)
+            $0.top.equalToSuperview().offset(Metric.logoTop)
+            $0.width.equalTo(Metric.logoSize)
+            $0.height.equalTo(Metric.logoSize)
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
- 스플래시 배경색을 `.white` → `#F4F4CC` 로 변경 (LaunchScreen과 동일)
- 로고 레이아웃을 LaunchScreen 고정 프레임과 동일하게 조정 (leading 29 / top 259, 335x335)
- 존재하지 않는 에셋명(`MemorySeal_Logo`) 참조로 로고가 표시되지 않던 문제 수정 → `MemorySealLogo`
- 로딩 인디케이터 제거

## 테스트 방법
- [ ] 앱 실행 시 LaunchScreen → 스플래시 전환에서 배경/로고 위치가 튀지 않는지 확인
- [ ] 자동 로그인 분기(홈 / 회원가입 / 로그인) 정상 동작 확인
- [ ] 노치 기기와 SE 계열 등 화면 크기가 다른 기기에서 로고 위치 확인