### PR TITLE
Feature: Universal Link / Push Notification 랜딩 처리 및 참여 링크 공유 구현

### DIFF
--- a/Projects/App/Sources/AppDelegate.swift
+++ b/Projects/App/Sources/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         FirebaseApp.configure()
 
-        UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
 
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
@@ -42,28 +41,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
         Messaging.messaging().apnsToken = deviceToken
-    }
-}
-
-// MARK: - UNUserNotificationCenterDelegate
-
-extension AppDelegate: UNUserNotificationCenterDelegate {
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        completionHandler([.banner, .badge, .sound])
-    }
-
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) {
-        let userInfo = response.notification.request.content.userInfo
-        print("📩 알림 탭: \(userInfo)")
-        completionHandler()
     }
 }
 

--- a/Projects/App/Sources/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate.swift
@@ -1,6 +1,8 @@
 import UIKit
+import UserNotifications
 
 import AppFeature
+import BaseDomain
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -12,13 +14,66 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
 
+        UNUserNotificationCenter.current().delegate = self
+
         let navigationController = UINavigationController()
         window?.rootViewController = navigationController
 
         let coordinator = AppCoordinator(with: navigationController)
         appCoordinator = coordinator
-        coordinator.start()
+        coordinator.start(destination: landingDestination(from: connectionOptions))
 
         window?.makeKeyAndVisible()
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard let destination = landingDestination(from: userActivity) else { return }
+        appCoordinator?.handle(destination: destination)
+    }
+
+    // MARK: - Landing
+
+    private func landingDestination(from connectionOptions: UIScene.ConnectionOptions) -> LandingDestination? {
+        if let response = connectionOptions.notificationResponse,
+           let destination = LandingLinkParser.parse(userInfo: response.notification.request.content.userInfo) {
+            return destination
+        }
+
+        return connectionOptions.userActivities
+            .compactMap { landingDestination(from: $0) }
+            .first
+    }
+
+    private func landingDestination(from userActivity: NSUserActivity) -> LandingDestination? {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL
+        else {
+            return nil
+        }
+
+        return LandingLinkParser.parse(url: url)
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension SceneDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .badge, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if let destination = LandingLinkParser.parse(userInfo: response.notification.request.content.userInfo) {
+            appCoordinator?.handle(destination: destination)
+        }
+        completionHandler()
     }
 }

--- a/Projects/App/Sources/Support/memorySeal.entitlements
+++ b/Projects/App/Sources/Support/memorySeal.entitlements
@@ -8,5 +8,9 @@
     <array>
         <string>Default</string>
     </array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:memory-seal-front.vercel.app</string>
+    </array>
 </dict>
 </plist>

--- a/Projects/Data/TicketData/Sources/Repository/DefaultJoinCapsuleRepository.swift
+++ b/Projects/Data/TicketData/Sources/Repository/DefaultJoinCapsuleRepository.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+import BaseData
+import TicketDomain
+
+public final class DefaultJoinCapsuleRepository: JoinCapsuleRepository {
+
+    private let provider: DefaultProvider<JoinCapsuleTargetType>
+
+    public init(provider: DefaultProvider<JoinCapsuleTargetType>) {
+        self.provider = provider
+    }
+
+    public func join(capsuleId: Int) async throws {
+        let result = await provider.request(.join(capsuleId: capsuleId))
+        try ResultHandler.handleResult(result: result, errorType: JoinCapsuleError.self)
+    }
+}

--- a/Projects/Data/TicketData/Sources/TargetType/JoinCapsuleTargetType.swift
+++ b/Projects/Data/TicketData/Sources/TargetType/JoinCapsuleTargetType.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Moya
+
+import BaseData
+
+public enum JoinCapsuleTargetType {
+    case join(capsuleId: Int)
+}
+
+extension JoinCapsuleTargetType: BaseTargetType {
+    public var path: String {
+        switch self {
+        case .join(let capsuleId):
+            return "/time-capsules/\(capsuleId)/join"
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .join:
+            return .post
+        }
+    }
+
+    public var task: Moya.Task {
+        switch self {
+        case .join:
+            return .requestPlain
+        }
+    }
+
+    public var headers: [String: String]? {
+        return nil
+    }
+
+    public var validationType: ValidationType {
+        return .successCodes
+    }
+
+    public var isNeededAccessToken: Bool {
+        switch self {
+        case .join:
+            return true
+        }
+    }
+}

--- a/Projects/Domain/BaseDomain/Sources/Entity/Landing/LandingDestination.swift
+++ b/Projects/Domain/BaseDomain/Sources/Entity/Landing/LandingDestination.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum LandingDestination {
+    case memberList(capsuleId: Int)
+    case openCapsule(capsuleId: Int)
+    case ticketDetail(capsuleId: Int)
+    case invite(capsuleId: Int)
+}

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingAction.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum LandingAction: String {
+    case member
+    case open
+    case detail
+    case invite
+}

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkBuilder.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkBuilder.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum LandingLinkBuilder {
+    public static func inviteLink(code: String, capsuleId: Int) -> URL? {
+        var components = URLComponents()
+        components.scheme = LandingLinkConfiguration.scheme
+        components.host = LandingLinkConfiguration.host
+        components.path = "/"
+        components.queryItems = [
+            URLQueryItem(name: LandingLinkConfiguration.codeKey, value: code),
+            URLQueryItem(name: LandingLinkConfiguration.actionKey, value: LandingAction.invite.rawValue),
+            URLQueryItem(name: LandingLinkConfiguration.capsuleIdKey, value: String(capsuleId))
+        ]
+
+        return components.url
+    }
+}

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkConfiguration.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkConfiguration.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum LandingLinkConfiguration {
+    public static let host: String = "memory-seal-front.vercel.app"
+    public static let actionKey: String = "action"
+    public static let capsuleIdKey: String = "capsuleId"
+}

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkConfiguration.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkConfiguration.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 public enum LandingLinkConfiguration {
+    public static let scheme: String = "https"
     public static let host: String = "memory-seal-front.vercel.app"
+    public static let codeKey: String = "code"
     public static let actionKey: String = "action"
     public static let capsuleIdKey: String = "capsuleId"
 }

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkParser.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkParser.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public enum LandingLinkParser {
+
+    private enum LandingAction: String {
+        case member
+        case open
+        case detail
+        case invite
+    }
+
+    public static func parse(url: URL) -> LandingDestination? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.host == LandingLinkConfiguration.host,
+              let queryItems = components.queryItems
+        else {
+            return nil
+        }
+
+        let action = queryItems.first { $0.name == LandingLinkConfiguration.actionKey }?.value
+        let capsuleId = queryItems.first { $0.name == LandingLinkConfiguration.capsuleIdKey }?.value
+
+        return makeDestination(action: action, capsuleId: capsuleId)
+    }
+
+    public static func parse(userInfo: [AnyHashable: Any]) -> LandingDestination? {
+        let action = stringValue(of: userInfo[LandingLinkConfiguration.actionKey])
+        let capsuleId = stringValue(of: userInfo[LandingLinkConfiguration.capsuleIdKey])
+
+        return makeDestination(action: action, capsuleId: capsuleId)
+    }
+
+    private static func makeDestination(action: String?, capsuleId: String?) -> LandingDestination? {
+        guard let rawAction = action?.trimmingCharacters(in: .whitespaces).lowercased(),
+              let landingAction = LandingAction(rawValue: rawAction),
+              let capsuleId = capsuleId.flatMap({ Int($0.trimmingCharacters(in: .whitespaces)) })
+        else {
+            return nil
+        }
+
+        switch landingAction {
+        case .member:
+            return .memberList(capsuleId: capsuleId)
+        case .open:
+            return .openCapsule(capsuleId: capsuleId)
+        case .detail:
+            return .ticketDetail(capsuleId: capsuleId)
+        case .invite:
+            return .invite(capsuleId: capsuleId)
+        }
+    }
+
+    private static func stringValue(of value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            return string
+        case let number as NSNumber:
+            return number.stringValue
+        default:
+            return nil
+        }
+    }
+}

--- a/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkParser.swift
+++ b/Projects/Domain/BaseDomain/Sources/Landing/LandingLinkParser.swift
@@ -2,13 +2,6 @@ import Foundation
 
 public enum LandingLinkParser {
 
-    private enum LandingAction: String {
-        case member
-        case open
-        case detail
-        case invite
-    }
-
     public static func parse(url: URL) -> LandingDestination? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               components.host == LandingLinkConfiguration.host,

--- a/Projects/Domain/TicketDomain/Sources/Entity/LandingResolution.swift
+++ b/Projects/Domain/TicketDomain/Sources/Entity/LandingResolution.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum LandingResolution {
+    case memberList(capsuleId: Int)
+    case openCapsule(capsuleId: Int)
+    case ticketDetail(capsuleId: Int)
+    case none
+}

--- a/Projects/Domain/TicketDomain/Sources/Error/JoinCapsuleError.swift
+++ b/Projects/Domain/TicketDomain/Sources/Error/JoinCapsuleError.swift
@@ -1,0 +1,9 @@
+import BaseDomain
+
+public enum JoinCapsuleError: DomainError {
+    case defaultError
+
+    public init(errorResponse: ErrorResponseEntity) {
+        self = .defaultError
+    }
+}

--- a/Projects/Domain/TicketDomain/Sources/Repository/JoinCapsuleRepository.swift
+++ b/Projects/Domain/TicketDomain/Sources/Repository/JoinCapsuleRepository.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol JoinCapsuleRepository {
+    func join(capsuleId: Int) async throws
+}

--- a/Projects/Domain/TicketDomain/Sources/UseCase/JoinCapsuleUseCase.swift
+++ b/Projects/Domain/TicketDomain/Sources/UseCase/JoinCapsuleUseCase.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public protocol JoinCapsuleUseCase {
+    func join(capsuleId: Int) async throws
+}
+
+public final class DefaultJoinCapsuleUseCase: JoinCapsuleUseCase {
+
+    private let joinCapsuleRepository: JoinCapsuleRepository
+
+    public init(joinCapsuleRepository: JoinCapsuleRepository) {
+        self.joinCapsuleRepository = joinCapsuleRepository
+    }
+
+    public func join(capsuleId: Int) async throws {
+        return try await joinCapsuleRepository.join(capsuleId: capsuleId)
+    }
+}

--- a/Projects/Domain/TicketDomain/Sources/UseCase/LandingUseCase.swift
+++ b/Projects/Domain/TicketDomain/Sources/UseCase/LandingUseCase.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+import BaseDomain
+
+public protocol LandingUseCase {
+    func resolve(_ destination: LandingDestination) async -> LandingResolution
+}
+
+public final class DefaultLandingUseCase: LandingUseCase {
+
+    private let ticketDetailUseCase: TicketDetailUseCase
+    private let joinCapsuleUseCase: JoinCapsuleUseCase
+
+    public init(
+        ticketDetailUseCase: TicketDetailUseCase,
+        joinCapsuleUseCase: JoinCapsuleUseCase
+    ) {
+        self.ticketDetailUseCase = ticketDetailUseCase
+        self.joinCapsuleUseCase = joinCapsuleUseCase
+    }
+
+    public func resolve(_ destination: LandingDestination) async -> LandingResolution {
+        switch destination {
+        case .memberList(let capsuleId):
+            guard await isAccessible(capsuleId: capsuleId) else { return .none }
+            return .memberList(capsuleId: capsuleId)
+
+        case .ticketDetail(let capsuleId):
+            guard await isAccessible(capsuleId: capsuleId) else { return .none }
+            return .ticketDetail(capsuleId: capsuleId)
+
+        case .openCapsule(let capsuleId):
+            guard let detail = try? await ticketDetailUseCase.fetchDetail(capsuleId: capsuleId),
+                  detail.timeCapsuleStatus == .opened
+            else {
+                return .none
+            }
+            return .openCapsule(capsuleId: capsuleId)
+
+        case .invite(let capsuleId):
+            if (try? await joinCapsuleUseCase.join(capsuleId: capsuleId)) != nil {
+                return .ticketDetail(capsuleId: capsuleId)
+            }
+            guard await isAccessible(capsuleId: capsuleId) else { return .none }
+            return .ticketDetail(capsuleId: capsuleId)
+        }
+    }
+
+    private func isAccessible(capsuleId: Int) async -> Bool {
+        return (try? await ticketDetailUseCase.fetchDetail(capsuleId: capsuleId)) != nil
+    }
+}

--- a/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
+++ b/Projects/Feature/AppFeature/Sources/Coordinator/AppCoordinator.swift
@@ -9,11 +9,13 @@ import UIKit
 
 import AuthFeature
 import MainFeature
+import BaseDomain
 
 public final class AppCoordinator {
     private let navigationController: UINavigationController
     private var authCoordinator: AuthCoordinator?
     private var mainCoordinator: MainCoordinator?
+    private var pendingDestination: LandingDestination?
 
     public init(
         with navigationController: UINavigationController
@@ -21,8 +23,17 @@ public final class AppCoordinator {
         self.navigationController = navigationController
     }
 
-    public func start() {
+    public func start(destination: LandingDestination? = nil) {
+        pendingDestination = destination
         moveToAuthCoordinator()
+    }
+
+    public func handle(destination: LandingDestination) {
+        guard let mainCoordinator else {
+            pendingDestination = destination
+            return
+        }
+        mainCoordinator.land(destination)
     }
 
     private func moveToAuthCoordinator() {
@@ -47,5 +58,13 @@ public final class AppCoordinator {
         let coordinator = MainCoordinator(with: navigationController, dependency: dependency)
         mainCoordinator = coordinator
         coordinator.start()
+
+        consumePendingDestination()
+    }
+
+    private func consumePendingDestination() {
+        guard let destination = pendingDestination else { return }
+        pendingDestination = nil
+        mainCoordinator?.land(destination)
     }
 }

--- a/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
+++ b/Projects/Feature/MainFeature/Sources/Coordinator/MainCoordinator.swift
@@ -12,6 +12,8 @@ import HomeFeature
 import ProfileFeature
 import CreateTicketFeature
 import TicketFeature
+import BaseDomain
+import TicketDomain
 
 public final class MainCoordinator {
     public struct Dependency {
@@ -28,6 +30,8 @@ public final class MainCoordinator {
     private var ticketCoordinator: TicketCoordinator?
     private var createTicketCoordinator: CreateTicketCoordinator?
     private let dependency: Dependency
+    private let mainDIContainer: MainDIContainer = .init()
+    private lazy var landingUseCase: LandingUseCase = mainDIContainer.makeLandingUseCase()
 
     public init(with navigationController: UINavigationController, dependency: Dependency) {
         self.navigationController = navigationController
@@ -94,5 +98,43 @@ public final class MainCoordinator {
         coordinator.startOpenFlow(onOpened: { [weak self] in
             self?.homeCoordinator?.refreshHome()
         })
+    }
+
+    private func moveToMemberListCoordinator(capsuleId: Int) {
+        let coordinator = TicketCoordinator(with: navigationController, capsuleId: capsuleId)
+        ticketCoordinator = coordinator
+        coordinator.startMemberList()
+    }
+
+    // MARK: - Landing
+
+    public func land(_ destination: LandingDestination) {
+        Task { [weak self] in
+            guard let self else { return }
+            let resolution = await self.landingUseCase.resolve(destination)
+            await MainActor.run {
+                self.route(resolution, from: destination)
+            }
+        }
+    }
+
+    private func route(_ resolution: LandingResolution, from destination: LandingDestination) {
+        if case .none = resolution { return }
+
+        navigationController.popToRootViewController(animated: false)
+
+        switch resolution {
+        case .memberList(let capsuleId):
+            moveToMemberListCoordinator(capsuleId: capsuleId)
+        case .openCapsule(let capsuleId):
+            moveToOpenCapsuleCoordinator(capsuleId: capsuleId)
+        case .ticketDetail(let capsuleId):
+            if case .invite = destination {
+                homeCoordinator?.refreshHome()
+            }
+            moveToTicketCoordinator(capsuleId: capsuleId)
+        case .none:
+            break
+        }
     }
 }

--- a/Projects/Feature/MainFeature/Sources/DIContainer/MainDIContainer.swift
+++ b/Projects/Feature/MainFeature/Sources/DIContainer/MainDIContainer.swift
@@ -8,6 +8,25 @@
 
 import Foundation
 
+import BaseData
+import TicketData
+import TicketDomain
+
 public final class MainDIContainer {
     public init() {}
+
+    func makeLandingUseCase() -> LandingUseCase {
+        let ticketDetailProvider = DefaultProvider<TicketDetailTargetType>()
+        let ticketDetailRepository = DefaultTicketDetailRepository(provider: ticketDetailProvider)
+        let ticketDetailUseCase = DefaultTicketDetailUseCase(ticketDetailRepository: ticketDetailRepository)
+
+        let joinCapsuleProvider = DefaultProvider<JoinCapsuleTargetType>()
+        let joinCapsuleRepository = DefaultJoinCapsuleRepository(provider: joinCapsuleProvider)
+        let joinCapsuleUseCase = DefaultJoinCapsuleUseCase(joinCapsuleRepository: joinCapsuleRepository)
+
+        return DefaultLandingUseCase(
+            ticketDetailUseCase: ticketDetailUseCase,
+            joinCapsuleUseCase: joinCapsuleUseCase
+        )
+    }
 }

--- a/Projects/Feature/TicketFeature/Sources/Coordinator/TicketCoordinator.swift
+++ b/Projects/Feature/TicketFeature/Sources/Coordinator/TicketCoordinator.swift
@@ -21,18 +21,30 @@ public final class TicketCoordinator {
     }
 
     public func start() {
+        self.navigationController.pushViewController(
+            makeTicketDetailViewController(),
+            animated: true
+        )
+    }
+
+    public func startMemberList() {
+        let ticketDetailViewController = makeTicketDetailViewController()
+        let addMemberViewController = ticketDIContainer.makeAddMemberViewController(capsuleId: capsuleId)
+
+        self.navigationController.setViewControllers(
+            navigationController.viewControllers + [ticketDetailViewController, addMemberViewController],
+            animated: true
+        )
+    }
+
+    private func makeTicketDetailViewController() -> TicketDetailViewController {
         let ticketDetailAction = TicketDetailViewModel.Action(
             moveToAddMember: moveToAddMember,
             moveToManageTicket: moveToManageTicket,
             moveToMyTicketMessages: moveToMyTicketMessages,
             moveToBuryTicket: moveToBuryTicket
         )
-        let ticketDetailViewController = ticketDIContainer.makeTicketDetailViewController(action: ticketDetailAction, capsuleId: capsuleId)
-
-        self.navigationController.pushViewController(
-            ticketDetailViewController,
-            animated: true
-        )
+        return ticketDIContainer.makeTicketDetailViewController(action: ticketDetailAction, capsuleId: capsuleId)
     }
 
     // MARK: - OpenFlow

--- a/Projects/Feature/TicketFeature/Sources/DIContainer/TicketDIContainer.swift
+++ b/Projects/Feature/TicketFeature/Sources/DIContainer/TicketDIContainer.swift
@@ -38,9 +38,15 @@ public final class TicketDIContainer {
         let provider = DefaultProvider<AddMemberTargetType>()
         let repository = DefaultAddMemberRepository(provider: provider)
         let useCase = DefaultAddMemberUseCase(addMemberRepository: repository)
+
+        let detailProvider = DefaultProvider<TicketDetailTargetType>()
+        let detailRepository = DefaultTicketDetailRepository(provider: detailProvider)
+        let ticketDetailUseCase = DefaultTicketDetailUseCase(ticketDetailRepository: detailRepository)
+
         return AddMemberViewModel(
             capsuleId: capsuleId,
-            addMemberUseCase: useCase
+            addMemberUseCase: useCase,
+            ticketDetailUseCase: ticketDetailUseCase
         )
     }
 

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Controller/AddMemberViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import Kingfisher
 
 import DesignSystem
 
@@ -151,6 +152,7 @@ extension AddMemberViewController {
             searchText: searchTextField.rx.text.orEmpty.asObservable(),
             prefetchRows: collectionView.rx.prefetchItems.asObservable(),
             didTapCopyInviteCode: didTapCopyInviteCode,
+            didTapShareLink: didTapShareLink,
             didConfirmDelegateHost: didConfirmDelegateHost,
             didConfirmKickContributor: didConfirmKickContributor
         )
@@ -206,6 +208,13 @@ extension AddMemberViewController {
             })
             .disposed(by: disposeBag)
 
+        output.inviteShare
+            .withUnretained(self)
+            .subscribe(onNext: { (self, content) in
+                self.presentShareSheet(with: content)
+            })
+            .disposed(by: disposeBag)
+
         output.errorToast
             .withUnretained(self)
             .subscribe(onNext: { (self, message) in
@@ -226,6 +235,29 @@ extension AddMemberViewController {
                 ToastView.show(on: self.view, message: "멤버를 추방했습니다.", position: .top)
             })
             .disposed(by: disposeBag)
+    }
+
+    private func presentShareSheet(with content: InviteShareContent) {
+        guard let thumbnailUrl = content.thumbnailUrl else {
+            presentActivityViewController(with: content, thumbnail: nil)
+            return
+        }
+
+        KingfisherManager.shared.retrieveImage(with: thumbnailUrl) { [weak self] result in
+            self?.presentActivityViewController(with: content, thumbnail: try? result.get().image)
+        }
+    }
+
+    private func presentActivityViewController(with content: InviteShareContent, thumbnail: UIImage?) {
+        let itemSource = InviteShareItemSource(content: content, thumbnail: thumbnail)
+        let activityViewController = UIActivityViewController(
+            activityItems: [itemSource],
+            applicationActivities: nil
+        )
+        activityViewController.popoverPresentationController?.sourceView = shareLinkPill
+        activityViewController.popoverPresentationController?.sourceRect = shareLinkPill.bounds
+
+        self.present(activityViewController, animated: true)
     }
 
     private func showMemberMoreSheet(for collaborator: CollaboratorEntity) {

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Model/InviteShareContent.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Model/InviteShareContent.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct InviteShareContent {
+    public let title: String
+    public let message: String
+    public let link: URL
+    public let thumbnailUrl: URL?
+
+    public init(
+        title: String,
+        message: String,
+        link: URL,
+        thumbnailUrl: URL?
+    ) {
+        self.title = title
+        self.message = message
+        self.link = link
+        self.thumbnailUrl = thumbnailUrl
+    }
+}

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/Model/InviteShareItemSource.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/Model/InviteShareItemSource.swift
@@ -1,0 +1,45 @@
+import UIKit
+import LinkPresentation
+
+final class InviteShareItemSource: NSObject, UIActivityItemSource {
+    private let content: InviteShareContent
+    private let thumbnail: UIImage?
+
+    init(content: InviteShareContent, thumbnail: UIImage?) {
+        self.content = content
+        self.thumbnail = thumbnail
+        super.init()
+    }
+
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return content.message
+    }
+
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        itemForActivityType activityType: UIActivity.ActivityType?
+    ) -> Any? {
+        return content.message
+    }
+
+    func activityViewController(
+        _ activityViewController: UIActivityViewController,
+        subjectForActivityType activityType: UIActivity.ActivityType?
+    ) -> String {
+        return content.title
+    }
+
+    func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.originalURL = content.link
+        metadata.url = content.link
+        metadata.title = content.title
+
+        if let thumbnail {
+            metadata.imageProvider = NSItemProvider(object: thumbnail)
+            metadata.iconProvider = NSItemProvider(object: thumbnail)
+        }
+
+        return metadata
+    }
+}

--- a/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
+++ b/Projects/Presentation/TicketPresentation/Sources/AddMember/ViewModel/AddMemberViewModel.swift
@@ -18,6 +18,7 @@ public final class AddMemberViewModel {
 
     private let capsuleId: Int
     private let addMemberUseCase: AddMemberUseCase
+    private let ticketDetailUseCase: TicketDetailUseCase
     private var cachedMemberList: [CollaboratorEntity] = []
 
     private let pageSize: Int = 20
@@ -28,10 +29,12 @@ public final class AddMemberViewModel {
 
     public init(
         capsuleId: Int,
-        addMemberUseCase: AddMemberUseCase
+        addMemberUseCase: AddMemberUseCase,
+        ticketDetailUseCase: TicketDetailUseCase
     ) {
         self.capsuleId = capsuleId
         self.addMemberUseCase = addMemberUseCase
+        self.ticketDetailUseCase = ticketDetailUseCase
     }
 
     struct Input {
@@ -39,6 +42,7 @@ public final class AddMemberViewModel {
         let searchText: Observable<String>
         let prefetchRows: Observable<[IndexPath]>
         let didTapCopyInviteCode: PublishRelay<Void>
+        let didTapShareLink: PublishRelay<Void>
         let didConfirmDelegateHost: PublishRelay<Int>
         let didConfirmKickContributor: PublishRelay<Int>
     }
@@ -47,6 +51,7 @@ public final class AddMemberViewModel {
         let memberList: PublishRelay<[CollaboratorEntity]>
         let isCurrentUserHost: BehaviorRelay<Bool>
         let inviteCode: PublishRelay<String>
+        let inviteShare: PublishRelay<InviteShareContent>
         let errorToast: PublishRelay<String>
         let delegateHostSuccess: PublishRelay<Void>
         let kickContributorSuccess: PublishRelay<Void>
@@ -56,6 +61,7 @@ public final class AddMemberViewModel {
         let memberList: PublishRelay<[CollaboratorEntity]> = .init()
         let isCurrentUserHost: BehaviorRelay<Bool> = .init(value: false)
         let inviteCode: PublishRelay<String> = .init()
+        let inviteShare: PublishRelay<InviteShareContent> = .init()
         let errorToast: PublishRelay<String> = .init()
         let delegateHostSuccess: PublishRelay<Void> = .init()
         let kickContributorSuccess: PublishRelay<Void> = .init()
@@ -169,6 +175,50 @@ public final class AddMemberViewModel {
             })
             .disposed(by: disposeBag)
 
+        input.didTapShareLink
+            .withUnretained(self)
+            .subscribe(onNext: { (self, _) in
+                Task { [weak self] in
+                    guard let self else { return }
+                    do {
+                        async let inviteCodeResult = self.addMemberUseCase.inviteToTimeCapsule(
+                            capsuleId: self.capsuleId
+                        )
+                        async let ticketDetailResult = self.ticketDetailUseCase.fetchDetail(
+                            capsuleId: self.capsuleId
+                        )
+                        let (code, ticketDetail) = try await (inviteCodeResult, ticketDetailResult)
+
+                        guard let link = LandingLinkBuilder.inviteLink(
+                            code: code,
+                            capsuleId: self.capsuleId
+                        ) else {
+                            await MainActor.run {
+                                errorToast.accept("참여 링크를 만들 수 없습니다")
+                            }
+                            return
+                        }
+
+                        let title = "\(ticketDetail.title)에서 초대가 왔어요!"
+                        let content = InviteShareContent(
+                            title: title,
+                            message: "\(title)\n\(link.absoluteString)",
+                            link: link,
+                            thumbnailUrl: ticketDetail.mainImageUrl.flatMap { URL(string: $0) }
+                        )
+
+                        await MainActor.run {
+                            inviteShare.accept(content)
+                        }
+                    } catch {
+                        await MainActor.run {
+                            errorToast.accept("참여 링크를 가져올 수 없습니다")
+                        }
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+
         input.didConfirmDelegateHost
             .withUnretained(self)
             .subscribe(onNext: { (self, targetUserId) in
@@ -219,6 +269,7 @@ public final class AddMemberViewModel {
             memberList: memberList,
             isCurrentUserHost: isCurrentUserHost,
             inviteCode: inviteCode,
+            inviteShare: inviteShare,
             errorToast: errorToast,
             delegateHostSuccess: delegateHostSuccess,
             kickContributorSuccess: kickContributorSuccess


### PR DESCRIPTION
Universal Link 또는 Push Notification 으로 앱에 진입했을 때 링크가 지정한 화면으로 바로 이동하도록 구현했습니다.
멤버 화면의 참여 링크 공유 버튼도 함께 연결했습니다.

## 링크 규격

```
https://memory-seal-front.vercel.app/?action=open&capsuleId=42
```

FCM data payload 도 동일한 키를 사용합니다. `{"action": "open", "capsuleId": "42"}`

| action | 목적지 | 최종 스택 |
|---|---|---|
| `member` | 멤버 목록 | 홈 → 티켓 상세 → 멤버 |
| `open` | 오픈 플로우 | 홈 → 오픈 플로우 |
| `detail` | 티켓 상세 | 홈 → 티켓 상세 |
| `invite` | join 후 티켓 상세 | 홈 → 티켓 상세 |

`code` 파라미터는 웹 랜딩 페이지 전용이라 앱에서는 파싱하지 않습니다. `action` 은 대소문자를 무시합니다.

## 변경 사항

### 랜딩 진입점 (App)
- `SceneDelegate` 가 UL/푸시 4경로를 모두 수집 — 앱 종료 상태(`connectionOptions.userActivities`, `notificationResponse`), 실행 중(`scene(_:continue:)`, `didReceive`)
- `UNUserNotificationCenterDelegate` 를 `AppDelegate` → `SceneDelegate` 로 이관. `AppDelegate` 에서 `AppCoordinator` 에 닿을 경로가 없어서 필요했습니다. 단일 씬 앱(`UIApplicationSupportsMultipleScenes: false`)이라 안전합니다
- `associated-domains` 엔타이틀먼트 추가

### 랜딩 조율 (Feature)
- `AppCoordinator` — 랜딩 요청을 pending 으로 보관했다가 홈 진입 시점에 소비. 콜드 스타트와 미로그인 진입이 같은 지점에서 해결됩니다 (미로그인 시 로그인 완료 후 목적지로 이어서 이동)
- `MainCoordinator.land(_:)` — 검증 후 홈까지 정리하고 목적지 push
- `TicketCoordinator.startMemberList()` — 멤버 화면 단독 진입용. 상세와 멤버를 한 번의 애니메이션으로 함께 쌓습니다

### 랜딩 검증 (Domain / Data)
- `LandingLinkParser` — URL·푸시 payload 파싱 (순수 함수)
- `LandingUseCase` — 이동 전 캡슐 접근 가능 여부 확인. `open` 은 `timeCapsuleStatus == 패 시 토스트 없이 홈에 머무릅니다
- `POST /time-capsules/{capsuleId}/join` 연동. 이미 참여한 사용자가 초대 링크를 다시 타면 join 이 실패하므로, 상세 접근 가능 여부를 재확인해 홈으로 튕기지 않게 폴백을 뒀습니다

### 참여 링크 공유 (Presentation)
- 기존에 relay 만 있고 아무 데도 연결되지 않았던 공유 버튼을 연결
- 공유 텍스트 `{티켓 이름}에서 초대가 왔어요!` + 개행 + 링크, 공유 시트 썸네일은 티켓 대표 이미지 (`LPLinkMetadata`)
- 초대 코드 발급과 티켓 상세 조회를 동시 호출. 썸네일 로드가 실패해도 공유는 그대로 진행됩니다